### PR TITLE
Export cesium context

### DIFF
--- a/src/core/context.tsx
+++ b/src/core/context.tsx
@@ -11,7 +11,8 @@ export interface CesiumProp<C> {
 export type WithContextProps<P, C> = P & CesiumProp<C>;
 export type WithContextType<P, C> = React.ComponentType<WithContextProps<P, C>>;
 
-export const { Provider, Consumer } = React.createContext<Context>({});
+export const CesiumContext = React.createContext<Context>({});
+export const { Provider, Consumer } = CesiumContext;
 
 export const withCesium = <P, C>(Component: WithContextType<P, C>) =>
   // supports both functional components and class components


### PR DESCRIPTION
A little modification in context definition to export React.createContext result.

This way, we can import the whole context and use the React contextType inside a component to easily access cesium objects without using Consumer.
See: https://reactjs.org/docs/context.html#classcontexttype