### PR TITLE
refactor: add default context type

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -45,6 +45,7 @@ overrides:
       - react
       - '@typescript-eslint'
       - react-hooks
+      - autofix
     extends:
       - prettier/react
       - plugin:react/recommended
@@ -59,6 +60,7 @@ overrides:
       react/prop-types: 'off'
       react-hooks/rules-of-hooks: error
       react-hooks/exhaustive-deps: error
+      # autofix/no-unused-vars: 'error'
     settings:
       react:
         version: detect

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint": "7.2.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-loader": "4.0.2",
+    "eslint-plugin-autofix": "^1.0.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.1.3",
     "eslint-plugin-react": "7.20.0",

--- a/src/Billboard/Billboard.ts
+++ b/src/Billboard/Billboard.ts
@@ -8,7 +8,6 @@ import {
   NearFarScalar,
   VerticalOrigin,
   Billboard as CesiumBillboard,
-  BillboardCollection,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -76,13 +75,7 @@ const cesiumProps: (keyof BillboardCesiumProps)[] = [
   "width",
 ];
 
-const Billboard = createCesiumComponent<
-  CesiumBillboard,
-  BillboardProps,
-  {
-    billboardCollection?: BillboardCollection;
-  }
->({
+const Billboard = createCesiumComponent<CesiumBillboard, BillboardProps>({
   name: "Billboard",
   create(context, props) {
     return context.billboardCollection?.add(props);

--- a/src/BillboardCollection/BillboardCollection.ts
+++ b/src/BillboardCollection/BillboardCollection.ts
@@ -1,10 +1,4 @@
-import {
-  BillboardCollection as CesiumBillboardCollection,
-  BlendOption,
-  Matrix4,
-  PrimitiveCollection,
-  Scene,
-} from "cesium";
+import { BillboardCollection as CesiumBillboardCollection, BlendOption, Matrix4 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -43,11 +37,7 @@ const cesiumProps: (keyof BillboardCollectionCesiumProps)[] = [
 
 const BillboardCollection = createCesiumComponent<
   CesiumBillboardCollection,
-  BillboardCollectionProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-    scene?: Scene;
-  }
+  BillboardCollectionProps
 >({
   name: "BillboardCollection",
   create(context, props) {

--- a/src/BillboardGraphics/BillboardGraphics.ts
+++ b/src/BillboardGraphics/BillboardGraphics.ts
@@ -10,7 +10,6 @@ import {
   BoundingRectangle,
   HeightReference,
   DistanceDisplayCondition,
-  Entity,
 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
@@ -84,13 +83,7 @@ const cesiumEventProps: EventkeyMap<CesiumBillboardGraphics, BillboardGraphicsCe
   onDefinitionChange: "definitionChanged",
 };
 
-const BillboardGraphics = createCesiumComponent<
-  CesiumBillboardGraphics,
-  BillboardGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const BillboardGraphics = createCesiumComponent<CesiumBillboardGraphics, BillboardGraphicsProps>({
   name: "BillboardGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/BoxGraphics/BoxGraphics.ts
+++ b/src/BoxGraphics/BoxGraphics.ts
@@ -1,6 +1,5 @@
 import {
   BoxGraphics as CesiumBoxGraphics,
-  Entity,
   Property,
   HeightReference,
   Cartesian3,
@@ -59,13 +58,7 @@ const cesiumEventProps: EventkeyMap<CesiumBoxGraphics, BoxGraphicsCesiumEvents> 
   onDefinitionChange: "definitionChanged",
 };
 
-const BoxGraphics = createCesiumComponent<
-  CesiumBoxGraphics,
-  BoxGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const BoxGraphics = createCesiumComponent<CesiumBoxGraphics, BoxGraphicsProps>({
   name: "BoxGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/Camera/Camera.ts
+++ b/src/Camera/Camera.ts
@@ -1,7 +1,6 @@
 import {
   Cartesian3,
   Camera as CesiumCamera,
-  Scene,
   PerspectiveFrustum,
   PerspectiveOffCenterFrustum,
   OrthographicFrustum,
@@ -94,13 +93,7 @@ const cesiumEventProps: EventkeyMap<CesiumCamera, CameraCesiumEvents> = {
   onMoveStart: "moveStart",
 };
 
-const Camera = createCesiumComponent<
-  CesiumCamera,
-  CameraProps,
-  {
-    scene?: Scene;
-  }
->({
+const Camera = createCesiumComponent<CesiumCamera, CameraProps>({
   name: "Camera",
   create: context => context.scene?.camera,
   cesiumProps,

--- a/src/CameraFlyHome/CameraFlyHome.ts
+++ b/src/CameraFlyHome/CameraFlyHome.ts
@@ -30,7 +30,7 @@ export interface CameraFlyHomeProps {
 const CameraFlyHome = createCameraOperation<CameraFlyHomeProps>(
   "CameraFlyHome",
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (camera, { cancelFlightOnUnmount, duration }) => {
+  (camera, { duration }) => {
     camera.flyHome(duration);
   },
 );

--- a/src/CameraFlyTo/CameraFlyTo.ts
+++ b/src/CameraFlyTo/CameraFlyTo.ts
@@ -40,7 +40,7 @@ export interface CameraFlyToProps {
 const CameraFlyTo = createCameraOperation<CameraFlyToProps>(
   "CameraFlyTo",
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (camera, { cancelFlightOnUnmount, ...props }) => {
+  (camera, { ...props }) => {
     camera.flyTo(props);
   },
 );

--- a/src/CameraFlyToBoundingSphere/CameraFlyToBoundingSphere.ts
+++ b/src/CameraFlyToBoundingSphere/CameraFlyToBoundingSphere.ts
@@ -40,7 +40,7 @@ export interface CameraFlyToBoundingSphereProps {
 const CameraFlyToBoundingSphere = createCameraOperation<CameraFlyToBoundingSphereProps>(
   "CameraFlyToBoundingSphere",
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (camera, { cancelFlightOnUnmount, boundingSphere, ...props }) => {
+  (camera, { boundingSphere, ...props }) => {
     camera.flyToBoundingSphere(boundingSphere, props);
   },
 );

--- a/src/Cesium3DTileset/Cesium3DTileset.ts
+++ b/src/Cesium3DTileset/Cesium3DTileset.ts
@@ -1,6 +1,5 @@
 import {
   Cesium3DTileset as CesiumCesium3DTileset,
-  PrimitiveCollection,
   Matrix4,
   ShadowMode,
   ClippingPlaneCollection,
@@ -173,13 +172,7 @@ const cesiumEventProps: EventkeyMap<CesiumCesium3DTileset, Cesium3DTilesetCesium
   onTileVisible: "tileVisible",
 };
 
-const Cesium3DTileset = createCesiumComponent<
-  CesiumCesium3DTileset,
-  Cesium3DTilesetProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-  }
->({
+const Cesium3DTileset = createCesiumComponent<CesiumCesium3DTileset, Cesium3DTilesetProps>({
   name: "Cesium3DTileset",
   create(context, props) {
     if (!context.primitiveCollection) return;

--- a/src/CesiumWidget/CesiumWidget.ts
+++ b/src/CesiumWidget/CesiumWidget.ts
@@ -11,13 +11,12 @@ import {
   MapProjection,
   ShadowMode,
   Globe,
-  Camera,
-  Scene,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 import EventManager, { eventManagerContextKey, RootEventProps } from "../core/EventManager";
 import { pick } from "../core/util";
+import { Context } from "../core/context";
 
 /*
 @summary
@@ -116,14 +115,8 @@ export interface CesiumWidgetProps
 const CesiumWidget = createCesiumComponent<
   CesiumCesiumWidget,
   CesiumWidgetProps,
-  undefined,
-  {
-    cesiumWidget: CesiumCesiumWidget;
-    scene: Scene;
-    globe: Globe;
-    camera: Camera;
-    [eventManagerContextKey]?: EventManager;
-  },
+  Context,
+  Context,
   EventManager
 >({
   name: "CesiumWidget",

--- a/src/Clock/Clock.ts
+++ b/src/Clock/Clock.ts
@@ -1,5 +1,5 @@
 import { createCesiumComponent, EventkeyMap } from "../core/component";
-import { ClockRange, ClockStep, JulianDate, Clock as CesiumClock, CesiumWidget } from "cesium";
+import { ClockRange, ClockStep, JulianDate, Clock as CesiumClock } from "cesium";
 
 /*
 @summary
@@ -47,13 +47,7 @@ const cesiumProps: (keyof ClockCesiumProps)[] = [
   "stopTime",
 ];
 
-const Clock = createCesiumComponent<
-  CesiumClock,
-  ClockProps,
-  {
-    cesiumWidget?: CesiumWidget;
-  }
->({
+const Clock = createCesiumComponent<CesiumClock, ClockProps>({
   name: "Clock",
   create: ctx => ctx.cesiumWidget?.clock,
   cesiumProps,

--- a/src/CorridorGraphics/CorridorGraphics.ts
+++ b/src/CorridorGraphics/CorridorGraphics.ts
@@ -9,7 +9,6 @@ import {
   DistanceDisplayCondition,
   ClassificationType,
   ConstantProperty,
-  Entity,
 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
@@ -77,13 +76,7 @@ const cesiumEventProps: EventkeyMap<CesiumCorridorGraphics, CorridorCesiumEvents
   onDefinitionChange: "definitionChanged",
 };
 
-const CorridorGraphics = createCesiumComponent<
-  CesiumCorridorGraphics,
-  CorridorGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const CorridorGraphics = createCesiumComponent<CesiumCorridorGraphics, CorridorGraphicsProps>({
   name: "CorridorGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/CustomDataSource/CustomDataSource.ts
+++ b/src/CustomDataSource/CustomDataSource.ts
@@ -1,9 +1,4 @@
-import {
-  CustomDataSource as CesiumCustomDataSource,
-  DataSourceClock,
-  EntityCluster,
-  DataSourceCollection,
-} from "cesium";
+import { CustomDataSource as CesiumCustomDataSource, DataSourceClock, EntityCluster } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
 
@@ -46,13 +41,7 @@ const cesiumEventProps: EventkeyMap<CesiumCustomDataSource, CustomDataSourceCesi
   onLoading: "loadingEvent",
 };
 
-const CustomDataSource = createCesiumComponent<
-  CesiumCustomDataSource,
-  CustomDataSourceProps,
-  {
-    dataSourceCollection?: DataSourceCollection;
-  }
->({
+const CustomDataSource = createCesiumComponent<CesiumCustomDataSource, CustomDataSourceProps>({
   name: "CustomDataSource",
   create(context, props) {
     if (!context.dataSourceCollection) return;

--- a/src/CylinderGraphics/CylinderGraphics.ts
+++ b/src/CylinderGraphics/CylinderGraphics.ts
@@ -1,6 +1,5 @@
 import {
   CylinderGraphics as CesiumCylinderGraphics,
-  Entity,
   Property,
   HeightReference,
   Color,
@@ -66,13 +65,7 @@ const cesiumEventProps: EventkeyMap<CesiumCylinderGraphics, CylinderCesiumEvents
   onDefinitionChange: "definitionChanged",
 };
 
-const CylinderGraphics = createCesiumComponent<
-  CesiumCylinderGraphics,
-  CylinderGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const CylinderGraphics = createCesiumComponent<CesiumCylinderGraphics, CylinderGraphicsProps>({
   name: "CylinderGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/CzmlDataSource/CzmlDataSource.ts
+++ b/src/CzmlDataSource/CzmlDataSource.ts
@@ -85,13 +85,7 @@ const load = ({
     });
 };
 
-const CzmlDataSource = createCesiumComponent<
-  CesiumCzmlDataSource,
-  CzmlDataSourceProps,
-  {
-    dataSourceCollection?: DataSourceCollection;
-  }
->({
+const CzmlDataSource = createCesiumComponent<CesiumCzmlDataSource, CzmlDataSourceProps>({
   name: "CzmlDataSource",
   create(context, props) {
     if (!context.dataSourceCollection) return;

--- a/src/EllipseGraphics/EllipseGraphics.ts
+++ b/src/EllipseGraphics/EllipseGraphics.ts
@@ -7,7 +7,6 @@ import {
   ShadowMode,
   DistanceDisplayCondition,
   ClassificationType,
-  Entity,
 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
@@ -79,13 +78,7 @@ const cesiumEventProps: EventkeyMap<CesiumEllipseGraphics, EllipseGraphicsCesium
   onDefinitionChange: "definitionChanged",
 };
 
-const EllipseGraphics = createCesiumComponent<
-  CesiumEllipseGraphics,
-  EllipseGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const EllipseGraphics = createCesiumComponent<CesiumEllipseGraphics, EllipseGraphicsProps>({
   name: "EllipseGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/EllipsoidGraphics/EllipsoidGraphics.ts
+++ b/src/EllipsoidGraphics/EllipsoidGraphics.ts
@@ -1,6 +1,5 @@
 import {
   EllipsoidGraphics as CesiumEllipsoidGraphics,
-  Entity,
   Property,
   HeightReference,
   Cartesian3,
@@ -77,13 +76,7 @@ const cesiumEventProps: EventkeyMap<CesiumEllipsoidGraphics, EllipsoidGraphicsCe
   onDefinitionChange: "definitionChanged",
 };
 
-const EllipsoidGraphics = createCesiumComponent<
-  CesiumEllipsoidGraphics,
-  EllipsoidGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const EllipsoidGraphics = createCesiumComponent<CesiumEllipsoidGraphics, EllipsoidGraphicsProps>({
   name: "EllipsoidGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/Entity/Entity.ts
+++ b/src/Entity/Entity.ts
@@ -22,8 +22,6 @@ import {
   PointGraphics,
   RectangleGraphics,
   WallGraphics,
-  Viewer,
-  EntityCollection,
   Cesium3DTilesetGraphics,
 } from "cesium";
 
@@ -174,14 +172,7 @@ const cesiumEventProps: EventkeyMap<CesiumEntity, EntityCesiumEvents> = {
   onDefinitionChange: "definitionChanged",
 };
 
-const Entity = createCesiumComponent<
-  CesiumEntity,
-  EntityProps,
-  {
-    entityCollection?: EntityCollection;
-    viewer?: Viewer;
-  }
->({
+const Entity = createCesiumComponent<CesiumEntity, EntityProps>({
   name: "Entity",
   create(context, props) {
     if (!context.entityCollection) return;

--- a/src/Fog/Fog.ts
+++ b/src/Fog/Fog.ts
@@ -1,5 +1,5 @@
 import { createCesiumComponent } from "../core/component";
-import { Fog as CesiumFog, Scene } from "cesium";
+import { Fog as CesiumFog } from "cesium";
 
 /*
 @summary
@@ -30,13 +30,7 @@ const cesiumProps: (keyof FogCesiumProps)[] = [
   "screenSpaceErrorFactor",
 ];
 
-const Fog = createCesiumComponent<
-  CesiumFog,
-  FogProps,
-  {
-    scene?: Scene;
-  }
->({
+const Fog = createCesiumComponent<CesiumFog, FogProps>({
   name: "Fog",
   create(context) {
     if (!context.scene) return;

--- a/src/GeoJsonDataSource/GeoJsonDataSource.ts
+++ b/src/GeoJsonDataSource/GeoJsonDataSource.ts
@@ -121,13 +121,7 @@ const load = ({
     });
 };
 
-const GeoJsonDataSource = createCesiumComponent<
-  CesiumGeoJsonDataSource,
-  GeoJsonDataSourceProps,
-  {
-    dataSourceCollection?: DataSourceCollection;
-  }
->({
+const GeoJsonDataSource = createCesiumComponent<CesiumGeoJsonDataSource, GeoJsonDataSourceProps>({
   name: "GeoJsonDataSource",
   create(context, props) {
     if (!context.dataSourceCollection) return;

--- a/src/Globe/Globe.ts
+++ b/src/Globe/Globe.ts
@@ -6,7 +6,6 @@ import {
   Material,
   ShadowMode,
   TerrainProvider,
-  Scene,
 } from "cesium";
 
 /*
@@ -110,13 +109,7 @@ const cesiumProps: (keyof GlobeCesiumProps)[] = [
   "tileCacheSize",
 ];
 
-const Globe = createCesiumComponent<
-  CesiumGlobe,
-  GlobeProps,
-  {
-    scene?: Scene;
-  }
->({
+const Globe = createCesiumComponent<CesiumGlobe, GlobeProps>({
   name: "Globe",
   create: context => context.scene?.globe,
   cesiumProps,

--- a/src/GroundPolylinePrimitive/GroundPolylinePrimitive.ts
+++ b/src/GroundPolylinePrimitive/GroundPolylinePrimitive.ts
@@ -1,4 +1,9 @@
-import { GroundPolylinePrimitive as CesiumGroundPolylinePrimitive } from "cesium";
+import {
+  GroundPolylinePrimitive as CesiumGroundPolylinePrimitive,
+  GeometryInstance,
+  Appearance,
+  ClassificationType,
+} from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 import { EventProps } from "../core/EventManager";
@@ -19,18 +24,18 @@ Otherwise, a primitive object will be attached to the PrimitiveCollection of the
 */
 
 export interface GroundPolylinePrimitiveCesiumProps {
-  appearance?: Cesium.Appearance;
+  appearance?: Appearance;
   debugShowBoundingVolume?: boolean;
   debugShowShadowVolume?: boolean;
-  classificationType?: any; // Cesium.ClassificationType
-  depthFailAppearance?: Cesium.Appearance;
+  classificationType?: ClassificationType;
+  depthFailAppearance?: Appearance;
   show?: boolean;
 }
 
 export interface GroundPolylinePrimitiveCesiumReadonlyProps {
   allowPicking?: boolean;
   asynchronous?: boolean;
-  geometryInstances?: Cesium.GeometryInstance[] | Cesium.GeometryInstance;
+  geometryInstances?: GeometryInstance[] | GeometryInstance;
   interleave?: boolean;
   releaseGeometryInstances?: boolean;
 }
@@ -41,7 +46,7 @@ export interface GroundPolylinePrimitiveProps
     EventProps<any> {
   // Cesium.GroundPolylinePrimitive
   // Calls when [Primitive#readyPromise](https://cesiumjs.org/Cesium/Build/Documentation/GroundPolylinePrimitive.html#readyPromise) is fullfilled
-  onReady?: (primitive: Cesium.GroundPolylinePrimitive) => void;
+  onReady?: (primitive: CesiumGroundPolylinePrimitive) => void;
 }
 
 const cesiumProps: (keyof GroundPolylinePrimitiveCesiumProps)[] = [
@@ -62,11 +67,8 @@ const cesiumReadonlyProps: (keyof GroundPolylinePrimitiveCesiumReadonlyProps)[] 
 ];
 
 const GroundPolylinePrimitive = createCesiumComponent<
-  Cesium.GroundPolylinePrimitive,
-  GroundPolylinePrimitiveProps,
-  {
-    primitiveCollection?: Cesium.PrimitiveCollection;
-  }
+  CesiumGroundPolylinePrimitive,
+  GroundPolylinePrimitiveProps
 >({
   name: "GroundPolylinePrimitive",
   create(context, props) {

--- a/src/GroundPrimitive/GroundPrimitive.ts
+++ b/src/GroundPrimitive/GroundPrimitive.ts
@@ -1,9 +1,4 @@
-import {
-  GroundPrimitive as CesiumGroundPrimitive,
-  PrimitiveCollection,
-  Appearance,
-  GeometryInstance,
-} from "cesium";
+import { GroundPrimitive as CesiumGroundPrimitive, Appearance, GeometryInstance } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 import { EventProps } from "../core/EventManager";
@@ -70,13 +65,7 @@ const cesiumReadonlyProps: (keyof GroundPrimitiveCesiumReadonlyProps)[] = [
   "vertexCacheOptimize",
 ];
 
-const GroundPrimitive = createCesiumComponent<
-  CesiumGroundPrimitive,
-  GroundPrimitiveProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-  }
->({
+const GroundPrimitive = createCesiumComponent<CesiumGroundPrimitive, GroundPrimitiveProps>({
   name: "GroundPrimitive",
   create(context, props) {
     if (!context.primitiveCollection) return;

--- a/src/GroundPrimitiveCollection/GroundPrimitiveCollection.ts
+++ b/src/GroundPrimitiveCollection/GroundPrimitiveCollection.ts
@@ -1,4 +1,4 @@
-import { PrimitiveCollection, Scene } from "cesium";
+import { PrimitiveCollection } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -28,11 +28,7 @@ const cesiumProps: (keyof GroundPrimitiveCollectionCesiumProps)[] = ["show"];
 
 const GroundPrimitiveCollection = createCesiumComponent<
   PrimitiveCollection,
-  GroundPrimitiveCollectionProps,
-  {
-    scene?: Scene;
-  },
-  { primitiveCollection: PrimitiveCollection }
+  GroundPrimitiveCollectionProps
 >({
   name: "GroundPrimitiveCollection",
   create: context => context.scene?.groundPrimitives,

--- a/src/ImageryLayer/ImageryLayer.ts
+++ b/src/ImageryLayer/ImageryLayer.ts
@@ -4,7 +4,6 @@ import {
   Rectangle,
   TextureMagnificationFilter,
   TextureMinificationFilter,
-  ImageryLayerCollection,
   ImagerySplitDirection,
 } from "cesium";
 
@@ -148,13 +147,7 @@ const cesiumReadonlyProps: (keyof ImageryLayerCesiumReadonlyProps)[] = [
   "maximumTerrainLevel",
 ];
 
-const ImageryLayer = createCesiumComponent<
-  CesiumImageryLayer,
-  ImageryLayerProps,
-  {
-    imageryLayerCollection?: ImageryLayerCollection;
-  }
->({
+const ImageryLayer = createCesiumComponent<CesiumImageryLayer, ImageryLayerProps>({
   name: "ImageryLayer",
   create(context, props) {
     if (!context.imageryLayerCollection) return;

--- a/src/ImageryLayerCollection/ImageryLayerCollection.ts
+++ b/src/ImageryLayerCollection/ImageryLayerCollection.ts
@@ -1,9 +1,5 @@
 import { createCesiumComponent, EventkeyMap } from "../core/component";
-import {
-  ImageryLayer,
-  ImageryLayerCollection as CesiumImageryLayerCollection,
-  Globe,
-} from "cesium";
+import { ImageryLayer, ImageryLayerCollection as CesiumImageryLayerCollection } from "cesium";
 
 /*
 @summary
@@ -39,10 +35,7 @@ const cesiumEventProps: EventkeyMap<
 
 const ImageryLayerCollection = createCesiumComponent<
   CesiumImageryLayerCollection,
-  ImageryLayerCollectionProps,
-  {
-    globe?: Globe;
-  }
+  ImageryLayerCollectionProps
 >({
   name: "ImageryLayerCollection",
   create: context => context.globe?.imageryLayers,

--- a/src/KmlDataSource/KmlDataSource.ts
+++ b/src/KmlDataSource/KmlDataSource.ts
@@ -6,7 +6,6 @@ import {
   Resource,
   EntityCluster,
   Camera,
-  Scene,
 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
@@ -101,14 +100,7 @@ const load = ({
   });
 };
 
-const KmlDataSource = createCesiumComponent<
-  CesiumKmlDataSource,
-  KmlDataSourceProps,
-  {
-    dataSourceCollection?: DataSourceCollection;
-    scene?: Scene;
-  }
->({
+const KmlDataSource = createCesiumComponent<CesiumKmlDataSource, KmlDataSourceProps>({
   name: "KmlDataSource",
   create(context, props) {
     if (!context.scene || !context.dataSourceCollection) return;

--- a/src/Label/Label.ts
+++ b/src/Label/Label.ts
@@ -9,7 +9,6 @@ import {
   LabelStyle,
   VerticalOrigin,
   Label as CesiumLabel,
-  LabelCollection,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -83,13 +82,7 @@ const cesiumProps: (keyof LabelCesiumProps)[] = [
   "verticalOrigin",
 ];
 
-const Label = createCesiumComponent<
-  CesiumLabel,
-  LabelProps,
-  {
-    labelCollection?: LabelCollection;
-  }
->({
+const Label = createCesiumComponent<CesiumLabel, LabelProps>({
   name: "Label",
   create: (context, props) => context.labelCollection?.add(props),
   destroy(element, context) {

--- a/src/LabelCollection/LabelCollection.ts
+++ b/src/LabelCollection/LabelCollection.ts
@@ -1,10 +1,4 @@
-import {
-  LabelCollection as CesiumLabelCollection,
-  Scene,
-  BlendOption,
-  Matrix4,
-  PrimitiveCollection,
-} from "cesium";
+import { LabelCollection as CesiumLabelCollection, BlendOption, Matrix4 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -39,14 +33,7 @@ const cesiumProps: (keyof LabelCollectionCesiumProps)[] = [
   "modelMatrix",
 ];
 
-const LabelCollection = createCesiumComponent<
-  CesiumLabelCollection,
-  LabelCollectionProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-    scene?: Scene;
-  }
->({
+const LabelCollection = createCesiumComponent<CesiumLabelCollection, LabelCollectionProps>({
   name: "LabelCollection",
   create(context, props) {
     if (!context.scene || !context.primitiveCollection) return;

--- a/src/LabelGraphics/LabelGraphics.ts
+++ b/src/LabelGraphics/LabelGraphics.ts
@@ -1,6 +1,5 @@
 import {
   LabelGraphics as CesiumLabelGraphics,
-  Entity,
   Property,
   Cartesian3,
   Cartesian2,
@@ -84,13 +83,7 @@ const cesiumEventProps: EventkeyMap<CesiumLabelGraphics, LabelGraphicsCesiumEven
   onDefinitionChange: "definitionChanged",
 };
 
-const LabelGraphics = createCesiumComponent<
-  CesiumLabelGraphics,
-  LabelGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const LabelGraphics = createCesiumComponent<CesiumLabelGraphics, LabelGraphicsProps>({
   name: "LabelGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -13,7 +13,6 @@ import {
   ShadowMode,
   Scene,
   Credit,
-  PrimitiveCollection,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -107,13 +106,7 @@ const cesiumReadonlyProps: (keyof ModelCesiumReadonlyProps)[] = [
   "credit",
 ];
 
-const Model = createCesiumComponent<
-  CesiumModel,
-  ModelProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-  }
->({
+const Model = createCesiumComponent<CesiumModel, ModelProps>({
   name: "Model",
   create(context, props) {
     if (!context.primitiveCollection) return;

--- a/src/ModelGraphics/ModelGraphics.ts
+++ b/src/ModelGraphics/ModelGraphics.ts
@@ -1,6 +1,5 @@
 import {
   ModelGraphics as CesiumModelGraphics,
-  Entity,
   Property,
   Color,
   Cartesian2,
@@ -81,13 +80,7 @@ const cesiumEventProps: EventkeyMap<CesiumModelGraphics, ModelGraphicsCesiumEven
   onDefinitionChange: "definitionChanged",
 };
 
-const ModelGraphics = createCesiumComponent<
-  CesiumModelGraphics,
-  ModelGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const ModelGraphics = createCesiumComponent<CesiumModelGraphics, ModelGraphicsProps>({
   name: "ModelGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/Moon/Moon.ts
+++ b/src/Moon/Moon.ts
@@ -1,4 +1,4 @@
-import { Moon as CesiumMoon, Scene, Ellipsoid } from "cesium";
+import { Moon as CesiumMoon, Ellipsoid } from "cesium";
 import { createCesiumComponent } from "../core/component";
 
 /*
@@ -29,13 +29,7 @@ const cesiumProps: (keyof MoonCesiumProps)[] = ["onlySunLighting", "show", "text
 
 const cesiumReadonlyProps: (keyof MoonCesiumReadonlyProps)[] = ["ellipsoid"];
 
-const Moon = createCesiumComponent<
-  CesiumMoon,
-  MoonProps,
-  {
-    scene?: Scene;
-  }
->({
+const Moon = createCesiumComponent<CesiumMoon, MoonProps>({
   name: "Moon",
   create(context, props) {
     if (!context.scene) return;

--- a/src/ParticleSystem/ParticleSystem.ts
+++ b/src/ParticleSystem/ParticleSystem.ts
@@ -1,10 +1,4 @@
-import {
-  ParticleSystem as CesiumParticleSystem,
-  Matrix4,
-  Color,
-  Cartesian2,
-  PrimitiveCollection,
-} from "cesium";
+import { ParticleSystem as CesiumParticleSystem, Matrix4, Color, Cartesian2 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
 
@@ -96,13 +90,7 @@ const cesiumEventProps: EventkeyMap<any, ParticleSystemCesiumEvents> = {
   onComplete: "complete",
 };
 
-const ParticleSystem = createCesiumComponent<
-  CesiumParticleSystem,
-  ParticleSystemProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-  }
->({
+const ParticleSystem = createCesiumComponent<CesiumParticleSystem, ParticleSystemProps>({
   name: "ParticleSystem",
   create(context, props) {
     if (!context.primitiveCollection) return;

--- a/src/PathGraphics/PathGraphics.ts
+++ b/src/PathGraphics/PathGraphics.ts
@@ -1,6 +1,5 @@
 import {
   PathGraphics as CesiumPathGraphics,
-  Entity,
   Property,
   DistanceDisplayCondition,
   Color,
@@ -50,13 +49,7 @@ const cesiumEventProps: EventkeyMap<CesiumPathGraphics, PathGraphicsCesiumEvents
   onDefinitionChange: "definitionChanged",
 };
 
-const PathGraphics = createCesiumComponent<
-  CesiumPathGraphics,
-  PathGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const PathGraphics = createCesiumComponent<CesiumPathGraphics, PathGraphicsProps>({
   name: "PathGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/PlaneGraphics/PlaneGraphics.ts
+++ b/src/PlaneGraphics/PlaneGraphics.ts
@@ -1,6 +1,5 @@
 import {
   PlaneGraphics as CesiumPlaneGraphics,
-  Entity,
   Property,
   Cartesian2,
   Color,
@@ -59,13 +58,7 @@ const cesiumEventProps: EventkeyMap<any, PlaneGraphicsCesiumEvents> = {
   onDefinitionChange: "definitionChanged",
 };
 
-const PlaneGraphics = createCesiumComponent<
-  CesiumPlaneGraphics,
-  PlaneGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const PlaneGraphics = createCesiumComponent<CesiumPlaneGraphics, PlaneGraphicsProps>({
   name: "PlaneGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/PointGraphics/PointGraphics.ts
+++ b/src/PointGraphics/PointGraphics.ts
@@ -1,6 +1,5 @@
 import {
   PointGraphics as CesiumPointGraphics,
-  Entity,
   Property,
   Color,
   NearFarScalar,
@@ -57,13 +56,7 @@ const cesiumEventProps: EventkeyMap<CesiumPointGraphics, PointGraphicsCesiumEven
   onDefinitionChange: "definitionChanged",
 };
 
-const PointGraphics = createCesiumComponent<
-  CesiumPointGraphics,
-  PointGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const PointGraphics = createCesiumComponent<CesiumPointGraphics, PointGraphicsProps>({
   name: "PointGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/PointPrimitive/PointPrimitive.ts
+++ b/src/PointPrimitive/PointPrimitive.ts
@@ -4,7 +4,6 @@ import {
   Color,
   NearFarScalar,
   PointPrimitive as CesiumPointPrimitive,
-  PointPrimitiveCollection,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -56,13 +55,7 @@ const cesiumProps: (keyof PointPrimitiveCesiumProps)[] = [
   "translucencyByDistance",
 ];
 
-const PointPrimitive = createCesiumComponent<
-  CesiumPointPrimitive,
-  PointPrimitiveProps,
-  {
-    pointPrimitiveCollection?: PointPrimitiveCollection;
-  }
->({
+const PointPrimitive = createCesiumComponent<CesiumPointPrimitive, PointPrimitiveProps>({
   name: "PointPrimitive",
   create: (context, props) => context.pointPrimitiveCollection?.add(props),
   destroy(element, context) {

--- a/src/PointPrimitiveCollection/PointPrimitiveCollection.ts
+++ b/src/PointPrimitiveCollection/PointPrimitiveCollection.ts
@@ -2,7 +2,6 @@ import {
   PointPrimitiveCollection as CesiumPointPrimitiveCollection,
   Matrix4,
   BlendOption,
-  PrimitiveCollection,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -40,10 +39,7 @@ const cesiumProps: (keyof PointPrimitiveCollectionCesiumProps)[] = [
 
 const PointPrimitiveCollection = createCesiumComponent<
   CesiumPointPrimitiveCollection,
-  PointPrimitiveCollectionProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-  }
+  PointPrimitiveCollectionProps
 >({
   name: "PointPrimitveCollection",
   create(context, props) {

--- a/src/PolygonGraphics/PolygonGraphics.ts
+++ b/src/PolygonGraphics/PolygonGraphics.ts
@@ -1,6 +1,5 @@
 import {
   PolygonGraphics as CesiumPolygonGraphics,
-  Entity,
   Property,
   HeightReference,
   PolygonHierarchy,
@@ -83,13 +82,7 @@ const cesiumEventProps: EventkeyMap<CesiumPolygonGraphics, PolygonGraphicsCesium
   onDefinitionChange: "definitionChanged",
 };
 
-const PolygonGraphics = createCesiumComponent<
-  CesiumPolygonGraphics,
-  PolygonGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const PolygonGraphics = createCesiumComponent<CesiumPolygonGraphics, PolygonGraphicsProps>({
   name: "PolygonGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/Polyline/Polyline.ts
+++ b/src/Polyline/Polyline.ts
@@ -1,10 +1,4 @@
-import {
-  Material,
-  Cartesian3,
-  DistanceDisplayCondition,
-  Polyline as CesiumPolyline,
-  PolylineCollection,
-} from "cesium";
+import { Material, Cartesian3, DistanceDisplayCondition, Polyline as CesiumPolyline } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 import { EventProps } from "../core/EventManager";
@@ -45,13 +39,7 @@ const cesiumProps: (keyof PolylineCesiumProps)[] = [
   "width",
 ];
 
-const Polyline = createCesiumComponent<
-  CesiumPolyline,
-  PolylineProps,
-  {
-    polylineCollection?: PolylineCollection;
-  }
->({
+const Polyline = createCesiumComponent<CesiumPolyline, PolylineProps>({
   name: "Polyline",
   create: (context, props) => context.polylineCollection?.add(props),
   destroy(element, context) {

--- a/src/PolylineCollection/PolylineCollection.ts
+++ b/src/PolylineCollection/PolylineCollection.ts
@@ -1,9 +1,4 @@
-import {
-  PolylineCollection as CesiumPolylineCollection,
-  Scene,
-  PrimitiveCollection,
-  Matrix4,
-} from "cesium";
+import { PolylineCollection as CesiumPolylineCollection, Matrix4 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -38,40 +33,35 @@ const cesiumProps: (keyof PolylineCollectionCesiumProps)[] = [
   "modelMatrix",
 ];
 
-const PolylineCollection = createCesiumComponent<
-  CesiumPolylineCollection,
-  PolylineCollectionProps,
+const PolylineCollection = createCesiumComponent<CesiumPolylineCollection, PolylineCollectionProps>(
   {
-    primitiveCollection?: PrimitiveCollection;
-    scene?: Scene;
-  }
->({
-  name: "PolylineCollection",
-  create(context, props) {
-    if (!context.primitiveCollection) return;
-    const element = new CesiumPolylineCollection({
-      modelMatrix: props.modelMatrix,
-      debugShowBoundingVolume: props.debugShowBoundingVolume,
-      length: props.length, // WORKAROUND: missing field
-      scene: context.scene,
-    } as any);
-    context.primitiveCollection.add(element);
-    return element;
+    name: "PolylineCollection",
+    create(context, props) {
+      if (!context.primitiveCollection) return;
+      const element = new CesiumPolylineCollection({
+        modelMatrix: props.modelMatrix,
+        debugShowBoundingVolume: props.debugShowBoundingVolume,
+        length: props.length, // WORKAROUND: missing field
+        scene: context.scene,
+      } as any);
+      context.primitiveCollection.add(element);
+      return element;
+    },
+    destroy(element, context) {
+      if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
+        context.primitiveCollection.remove(element);
+      }
+      if (!element.isDestroyed()) {
+        element.destroy();
+      }
+    },
+    provide(element) {
+      return {
+        polylineCollection: element,
+      };
+    },
+    cesiumProps,
   },
-  destroy(element, context) {
-    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      context.primitiveCollection.remove(element);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
-    }
-  },
-  provide(element) {
-    return {
-      polylineCollection: element,
-    };
-  },
-  cesiumProps,
-});
+);
 
 export default PolylineCollection;

--- a/src/PolylineGraphics/PolylineGraphics.ts
+++ b/src/PolylineGraphics/PolylineGraphics.ts
@@ -1,6 +1,5 @@
 import {
   PolylineGraphics as CesiumPolylineGraphics,
-  Entity,
   MaterialProperty,
   Color,
   ShadowMode,
@@ -62,13 +61,7 @@ const cesiumEventProps: EventkeyMap<CesiumPolylineGraphics, PolylineGraphicsCesi
   onDefinitionChange: "definitionChanged",
 };
 
-const PolylineGraphics = createCesiumComponent<
-  CesiumPolylineGraphics,
-  PolylineGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const PolylineGraphics = createCesiumComponent<CesiumPolylineGraphics, PolylineGraphicsProps>({
   name: "PolylineGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/PolylineVolumeGraphics/PolylineVolumeGraphics.ts
+++ b/src/PolylineVolumeGraphics/PolylineVolumeGraphics.ts
@@ -1,6 +1,5 @@
 import {
   PolylineVolumeGraphics as CesiumPolylineVolumeGraphics,
-  Entity,
   Property,
   CornerType,
   Cartesian2,
@@ -71,10 +70,7 @@ const cesiumEventProps: EventkeyMap<
 
 const PolylineVolumeGraphics = createCesiumComponent<
   CesiumPolylineVolumeGraphics,
-  PolylineVolumeGraphicsProps,
-  {
-    entity?: Entity;
-  }
+  PolylineVolumeGraphicsProps
 >({
   name: "PolylineVolumeGraphics",
   create(context, props) {

--- a/src/PostProcessStage/PostProcessStage.ts
+++ b/src/PostProcessStage/PostProcessStage.ts
@@ -3,7 +3,6 @@ import {
   BoundingRectangle,
   Color,
   PixelFormat,
-  Scene,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -91,10 +90,7 @@ const cesiumReadonlyProps: (keyof PostProcessStageCesiumReadonlyProps)[] = [
 
 export const PostProcessStage = createCesiumComponent<
   CesiumPostProcessStage,
-  PostProcessStageProps,
-  {
-    scene?: Scene;
-  }
+  PostProcessStageProps
 >({
   name: "PostProcessStage",
   create(context, props) {

--- a/src/PostProcessStageComposite/PostProcessStageComposite.ts
+++ b/src/PostProcessStageComposite/PostProcessStageComposite.ts
@@ -1,6 +1,5 @@
 import {
   PostProcessStageComposite as CesiumPostProcessStageComposite,
-  Scene,
   PostProcessStage,
 } from "cesium";
 
@@ -84,10 +83,7 @@ const cesiumReadonlyProps: (keyof PostProcessStageCompositeCesiumReadonlyProps)[
 
 export const PostProcessStageComposite = createCesiumComponent<
   CesiumPostProcessStageComposite,
-  PostProcessStageCompositeProps,
-  {
-    scene?: Scene;
-  }
+  PostProcessStageCompositeProps
 >({
   name: "PostProcessStageComposite",
   create(context, props) {

--- a/src/Primitive/Primitive.ts
+++ b/src/Primitive/Primitive.ts
@@ -4,7 +4,6 @@ import {
   ShadowMode,
   Matrix4,
   GeometryInstance,
-  PrimitiveCollection,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -72,13 +71,7 @@ const cesiumReadonlyProps: (keyof PrimitiveCesiumReadonlyProps)[] = [
   "vertexCacheOptimize",
 ];
 
-const Primitive = createCesiumComponent<
-  CesiumPrimitive,
-  PrimitiveProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-  }
->({
+const Primitive = createCesiumComponent<CesiumPrimitive, PrimitiveProps>({
   name: "Primitive",
   create(context, props) {
     if (!context.primitiveCollection) return;

--- a/src/RectangleGraphics/RectangleGraphics.ts
+++ b/src/RectangleGraphics/RectangleGraphics.ts
@@ -8,7 +8,6 @@ import {
   MaterialProperty,
   HeightReference,
   Rectangle,
-  Entity,
 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
@@ -77,13 +76,7 @@ const cesiumEventProps: EventkeyMap<CesiumRectangleGraphics, RectangleGraphicsCe
   onDefinitionChange: "definitionChanged",
 };
 
-const RectangleGraphics = createCesiumComponent<
-  CesiumRectangleGraphics,
-  RectangleGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const RectangleGraphics = createCesiumComponent<CesiumRectangleGraphics, RectangleGraphicsProps>({
   name: "RectangleGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/Scene/Scene.ts
+++ b/src/Scene/Scene.ts
@@ -187,13 +187,7 @@ const morph = (scene: CesiumScene, mode: SceneMode, morphTime?: number) => {
   }
 };
 
-const Scene = createCesiumComponent<
-  CesiumScene,
-  SceneProps,
-  {
-    scene?: CesiumScene;
-  }
->({
+const Scene = createCesiumComponent<CesiumScene, SceneProps>({
   name: "Scene",
   create(context, props) {
     if (context.scene && props.mode) {

--- a/src/ScreenSpaceCameraController/ScreenSpaceCameraController.ts
+++ b/src/ScreenSpaceCameraController/ScreenSpaceCameraController.ts
@@ -2,7 +2,6 @@ import {
   ScreenSpaceCameraController as CesiumScreenSpaceCameraController,
   CameraEventType,
   KeyboardEventModifier,
-  Scene,
 } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
@@ -91,10 +90,7 @@ const cesiumProps: (keyof ScreenSpaceCameraControllerCesiumProps)[] = [
 
 const ScreenSpaceCameraController = createCesiumComponent<
   CesiumScreenSpaceCameraController,
-  ScreenSpaceCameraControllerCesiumProps,
-  {
-    scene?: Scene;
-  }
+  ScreenSpaceCameraControllerCesiumProps
 >({
   name: "ScreenSpaceCameraController",
   create: context => context.scene?.screenSpaceCameraController,

--- a/src/ScreenSpaceEventHandler/ScreenSpaceEventHandler.ts
+++ b/src/ScreenSpaceEventHandler/ScreenSpaceEventHandler.ts
@@ -1,8 +1,4 @@
-import {
-  ScreenSpaceEventHandler as CesiumScreenSpaceEventHandler,
-  Scene,
-  CesiumWidget,
-} from "cesium";
+import { ScreenSpaceEventHandler as CesiumScreenSpaceEventHandler } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -26,11 +22,7 @@ export interface ScreenSpaceEventHandlerProps {
 
 const ScreenSpaceEventHandler = createCesiumComponent<
   CesiumScreenSpaceEventHandler,
-  ScreenSpaceEventHandlerProps,
-  {
-    scene?: Scene;
-    cesiumWidget?: CesiumWidget;
-  }
+  ScreenSpaceEventHandlerProps
 >({
   name: "ScreenSpaceEventHandler",
   create(context, props) {

--- a/src/ShadowMap/ShadowMap.ts
+++ b/src/ShadowMap/ShadowMap.ts
@@ -1,4 +1,4 @@
-import { Scene, ShadowMap as CesiumShadowMap } from "cesium";
+import { ShadowMap as CesiumShadowMap } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -30,13 +30,7 @@ const cesiumProps: (keyof ShadowMapProps)[] = [
   "softShadows",
 ];
 
-const ShadowMap = createCesiumComponent<
-  CesiumShadowMap,
-  ShadowMapProps,
-  {
-    scene?: Scene;
-  }
->({
+const ShadowMap = createCesiumComponent<CesiumShadowMap, ShadowMapProps>({
   name: "ShadowMap",
   create: context => context.scene?.shadowMap,
   cesiumProps,

--- a/src/SkyAtmosphere/SkyAtmosphere.ts
+++ b/src/SkyAtmosphere/SkyAtmosphere.ts
@@ -1,4 +1,4 @@
-import { Scene, SkyAtmosphere as CesiumSkyAtmosphere } from "cesium";
+import { SkyAtmosphere as CesiumSkyAtmosphere } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -31,13 +31,7 @@ const cesiumProps: (keyof SkyAtmosphereCesiumProps)[] = [
   "show",
 ];
 
-const SkyAtmosphere = createCesiumComponent<
-  CesiumSkyAtmosphere,
-  SkyAtmosphereProps,
-  {
-    scene?: Scene;
-  }
->({
+const SkyAtmosphere = createCesiumComponent<CesiumSkyAtmosphere, SkyAtmosphereProps>({
   name: "SkyAtmosphere",
   create: context => context.scene?.skyAtmosphere,
   cesiumProps,

--- a/src/SkyBox/SkyBox.ts
+++ b/src/SkyBox/SkyBox.ts
@@ -1,4 +1,4 @@
-import { SkyBox as CesiumSkyBox, Scene } from "cesium";
+import { SkyBox as CesiumSkyBox } from "cesium";
 
 import { createCesiumComponent } from "../core/component";
 
@@ -31,13 +31,7 @@ export interface SkyBoxProps extends SkyBoxCesiumProps {}
 
 const cesiumProps: (keyof SkyBoxCesiumProps)[] = ["sources", "show"];
 
-const SkyBox = createCesiumComponent<
-  CesiumSkyBox,
-  SkyBoxProps,
-  {
-    scene?: Scene;
-  }
->({
+const SkyBox = createCesiumComponent<CesiumSkyBox, SkyBoxProps>({
   name: "SkyBox",
   create: context => context.scene?.skyBox,
   cesiumProps,

--- a/src/Sun/Sun.ts
+++ b/src/Sun/Sun.ts
@@ -1,4 +1,4 @@
-import { Sun as CesiumSun, Scene } from "cesium";
+import { Sun as CesiumSun } from "cesium";
 import { createCesiumComponent } from "../core/component";
 
 /*
@@ -23,13 +23,7 @@ export interface SunProps extends SunCesiumProps {}
 
 const cesiumProps: (keyof SunCesiumProps)[] = ["glowFactor", "show"];
 
-const Sun = createCesiumComponent<
-  CesiumSun,
-  SunProps,
-  {
-    scene?: Scene;
-  }
->({
+const Sun = createCesiumComponent<CesiumSun, SunProps>({
   name: "Sun",
   create(context) {
     if (!context.scene) return;

--- a/src/TimeDynamicPointCloud/TimeDynamicPointCloud.ts
+++ b/src/TimeDynamicPointCloud/TimeDynamicPointCloud.ts
@@ -6,8 +6,6 @@ import {
   Matrix4,
   ShadowMode,
   Cesium3DTileStyle,
-  PrimitiveCollection,
-  CesiumWidget,
 } from "cesium";
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
@@ -81,11 +79,7 @@ const cesiumEventProps: EventkeyMap<
 
 const TimeDynamicPointCloud = createCesiumComponent<
   CesiumTimeDynamicPointCloud,
-  TimeDynamicPointCloudProps,
-  {
-    primitiveCollection?: PrimitiveCollection;
-    cesiumWidget?: CesiumWidget;
-  }
+  TimeDynamicPointCloudProps
 >({
   name: "TimeDynamicPointCloud",
   create(context, props) {

--- a/src/Viewer/Viewer.ts
+++ b/src/Viewer/Viewer.ts
@@ -2,10 +2,6 @@ import React from "react";
 import {
   Viewer as CesiumViewer,
   Globe,
-  Camera,
-  Scene,
-  EntityCollection,
-  CesiumWidget,
   DataSourceCollection,
   ImageryProvider,
   MapProjection,
@@ -23,6 +19,7 @@ import {
 
 import { createCesiumComponent, EventkeyMap } from "../core/component";
 import EventManager, { eventManagerContextKey, RootEventProps } from "../core/EventManager";
+import { Context } from "../core/context";
 
 /*
 @summary
@@ -180,22 +177,7 @@ export interface ViewerProps
   children?: React.ReactNode;
 }
 
-const Viewer = createCesiumComponent<
-  CesiumViewer,
-  ViewerProps,
-  undefined,
-  {
-    viewer: CesiumViewer;
-    cesiumWidget: CesiumWidget;
-    dataSourceCollection: DataSourceCollection;
-    entityCollection: EntityCollection;
-    scene: Scene;
-    globe: Globe;
-    camera: Camera;
-    [eventManagerContextKey]?: EventManager;
-  },
-  EventManager
->({
+const Viewer = createCesiumComponent<CesiumViewer, ViewerProps, Context, Context, EventManager>({
   name: "Viewer",
   create(_context, props, wrapper) {
     if (!wrapper) return;

--- a/src/WallGraphics/WallGraphics.ts
+++ b/src/WallGraphics/WallGraphics.ts
@@ -1,6 +1,5 @@
 import {
   WallGraphics as CesiumWallGraphics,
-  Entity,
   Property,
   Cartesian3,
   MaterialProperty,
@@ -62,13 +61,7 @@ const cesiumEventProps: EventkeyMap<CesiumWallGraphics, WallGraphicsCesiumEvents
   onDefinitionChange: "definitionChanged",
 };
 
-const WallGraphics = createCesiumComponent<
-  CesiumWallGraphics,
-  WallGraphicsProps,
-  {
-    entity?: Entity;
-  }
->({
+const WallGraphics = createCesiumComponent<CesiumWallGraphics, WallGraphicsProps>({
   name: "WallGraphics",
   create(context, props) {
     if (!context.entity) return;

--- a/src/core/component.test.tsx
+++ b/src/core/component.test.tsx
@@ -196,6 +196,7 @@ describe("core/component", () => {
     const Component1 = createCesiumComponent<
       string,
       { children?: React.ReactNode },
+      any,
       { context: string }
     >({
       name: "test",

--- a/src/core/component.tsx
+++ b/src/core/component.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 
 import { useCesiumComponent, Options, EventkeyMap } from "./hooks";
-import { CesiumContext } from "./context";
+import { CesiumContext, Context } from "./context";
 import { pick } from "./util";
 
 export { EventkeyMap };
@@ -34,8 +34,8 @@ export type CesiumComponentType<Element, Props> = React.ForwardRefExoticComponen
 export const createCesiumComponent = <
   Element,
   Props,
-  Context = any,
-  ProvidecContext = any,
+  Ctx = Context,
+  ProvidecContext = Context,
   State = any
 >({
   renderContainer,
@@ -43,7 +43,7 @@ export const createCesiumComponent = <
   containerProps,
   defaultProps,
   ...options
-}: CesiumComponentOptions<Element, Props, Context, ProvidecContext, State>): CesiumComponentType<
+}: CesiumComponentOptions<Element, Props, Ctx, ProvidecContext, State>): CesiumComponentType<
   Element,
   Props
 > => {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,5 +1,44 @@
 import { createContext, useContext } from "react";
+import {
+  Viewer,
+  CesiumWidget,
+  Scene,
+  Globe,
+  Camera,
+  ScreenSpaceEventHandler,
+  Entity,
+  DataSourceCollection,
+  DataSource,
+  EntityCollection,
+  ImageryLayerCollection,
+  PrimitiveCollection,
+  BillboardCollection,
+  LabelCollection,
+  PolylineCollection,
+  PointPrimitiveCollection,
+} from "cesium";
+import EventManager, { eventManagerContextKey } from "./EventManager";
+
+export type Context = {
+  viewer?: Viewer;
+  cesiumWidget?: CesiumWidget;
+  scene?: Scene;
+  globe?: Globe;
+  camera?: Camera;
+  screenSpaceEventHandler?: ScreenSpaceEventHandler;
+  entity?: Entity;
+  dataSourceCollection?: DataSourceCollection;
+  dataSource?: DataSource;
+  entityCollection?: EntityCollection;
+  imageryLayerCollection?: ImageryLayerCollection;
+  primitiveCollection?: PrimitiveCollection;
+  billboardCollection?: BillboardCollection;
+  labelCollection?: LabelCollection;
+  polylineCollection?: PolylineCollection;
+  pointPrimitiveCollection?: PointPrimitiveCollection;
+  [eventManagerContextKey]?: EventManager;
+};
 
 export const CesiumContext = createContext<any>({});
 export const { Provider, Consumer } = CesiumContext;
-export const useCesium = <T extends any>() => useContext(CesiumContext) as T;
+export const useCesium = <T = Context>() => useContext(CesiumContext) as T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,6 +4815,17 @@ eslint-loader@4.0.2:
     object-hash "^2.0.3"
     schema-utils "^2.6.5"
 
+eslint-plugin-autofix@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-autofix/-/eslint-plugin-autofix-1.0.0.tgz#4efc1bbfbf6138d5cc83efd1564ff048a372f2f9"
+  integrity sha512-cgZhGQB2xa3ZS9fqSz3EumqOFVpsV7vy+YQJvOF7PUAQ7T0dIYfoHY2+DtjFq5vaXj2cSaCPXw/YXI34ANLa9A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+    espree "^6.1.2"
+    esutils "^2.0.2"
+    lodash "^4.17.15"
+    string-similarity "^4.0.1"
+
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
@@ -4863,6 +4874,11 @@ eslint-plugin-react@7.20.0:
     resolve "^1.15.1"
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -4933,6 +4949,15 @@ eslint@7.2.0:
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
 
 espree@^7.1.0:
   version "7.1.0"
@@ -10295,6 +10320,11 @@ string-length@^4.0.1:
   dependencies:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
+
+string-similarity@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.1.tgz#ea7c11f0093cb3088cdcc5eb16cfd90cb54962f7"
+  integrity sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Adding type arg for `useCesium` is no longer needed.

```ts
const viewer = useCesium<{ viewer?: Viewer }>().viewer;
```

=>

```ts
const viewer = useCesium().viewer;
```

