### PR TITLE
Allow for removal of Bing Maps session

### DIFF
--- a/src/Viewer/Viewer.ts
+++ b/src/Viewer/Viewer.ts
@@ -136,7 +136,7 @@ export type ViewerProps = ViewerCesiumProps &
 
 const Viewer = createCesiumComponent<CesiumViewer, ViewerProps, EventManager>({
   name: "Viewer",
-  async create(_context, { baseLayer, terrainProvider, ...props }, wrapper) {
+  async create(_context, { terrainProvider, ...props }, wrapper) {
     if (!wrapper) return;
 
     let resultTerrainProvider: TerrainProvider;
@@ -149,11 +149,10 @@ const Viewer = createCesiumComponent<CesiumViewer, ViewerProps, EventManager>({
     const v = new CesiumViewer(wrapper, {
       ...props,
       terrainProvider: resultTerrainProvider,
-      baseLayer: baseLayer === false ? undefined : baseLayer,
     });
     if (!v) return;
 
-    if (baseLayer === false) {
+    if (props.baseLayer === false) {
       v.imageryLayers.removeAll();
     }
 


### PR DESCRIPTION
# Overview

Currently, even with `baseLayer={false}` and `baseLayerPicker={false}`, the `<Viewer />` ends up creating a Bing Maps session. Can confirm by observing a request made to `dev.virtualearth.net` in the browser Network tab.

This PR resolves #707 by allowing `baseLayer: false` to pass into the `Cesium.Viewer` constructor.

## Details

[`baseLayer: false` has different behavior from `baseLayer: undefined`](https://cesium.com/learn/ion-sdk/ref-doc/Viewer.html#.ConstructorOptions), so the existing code wasn't allowing for disabling the default Bing Maps baseLayer.

To fix the bug here, I removed the destructured `baseLayer` prop so it just gets passed in with `...props`. I left the `imageryLayers.removeAll()` since it doesn't appear to be hurting anything.

Confirmed this change clears the `dev.virtualearth.net` request from the Network tab with `<Viewer baseLayer={false} baseLayerPicker={false} />`.