### PR TITLE
chore: Add Automated Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,17 @@ jobs:
     # Temporarily disabled for testing on feature branch
     # if: github.ref == 'refs/heads/main'
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Set up git config
         run: |
           git config --global user.name "${{ github.actor }}"
@@ -60,7 +66,7 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || steps.changelog.outputs.version }}
           TAG: v${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || steps.changelog.outputs.version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Create release branch
           BRANCH="chore/release-${VERSION}"


### PR DESCRIPTION
## Add Automated Release Workflow

  This PR adds an automated release workflow to streamline the release preparation process.

  ### What's New

  - **Automated Release Workflow** (`.github/workflows/release.yml`): A GitHub Actions workflow that automates version bumping and CHANGELOG generation

  ### How It Works

  The workflow can be manually triggered from the GitHub Actions UI with the following options:
  - **Version bump type**: patch, minor, major, or custom
  - **Custom version**: For specific versions like beta releases (e.g., `1.19.0-beta.1`)

  When triggered, the workflow:
  1. Runs tests and build to ensure everything passes
  2. Generates a CHANGELOG based on conventional commits since the last release
  3. Updates `package.json` with the new version
  4. Creates a release branch (e.g., `chore/release-1.19.0`)
  5. Commits the changes
  6. **Automatically creates a PR** for review

  ### Authentication

  The workflow uses GitHub App authentication via the `tibdex/github-app-token` action, which requires:
  - `GH_APP_ID` secret
  - `GH_APP_PRIVATE_KEY` secret

  These should already be configured at the organization level. If not, please coordinate with the organization admin.

  ### Testing Configuration

  **Note**: The workflow currently has a temporary configuration for testing:
  ```yaml
  # Temporarily disabled for testing on feature branch
  # if: github.ref == 'refs/heads/main'

  After merging and successful testing, this should be re-enabled to ensure the workflow only runs from the main branch.

  Testing Instructions

  After merging this PR:

  1. Go to: https://github.com/reearth/resium/actions/workflows/release.yml
  2. Click "Run workflow"
  3. Select version type (suggest "patch" for first test)
  4. Click "Run workflow"
  5. Verify it creates a release PR successfully
  6. Close/delete the test PR
  7. Create a follow-up PR to re-enable the main branch check

  Benefits

  - Consistency: Automated CHANGELOG generation from conventional commits
  - Safety: Creates a PR for review rather than pushing directly to main
  - Efficiency: Reduces manual work in release preparation
  - Standardization: Follows the same pattern as other repositories in the organization

  Related Work

  This follows the same release workflow pattern used in other repositories and was developed alongside the Cesium library upgrade from 1.116.0 to
  1.134.1.