### PR TITLE
Delete branch if it already exists before creating the release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,12 @@ jobs:
         run: |
           # Create release branch
           BRANCH="chore/release-${VERSION}"
+
+          # Delete existing branch if it exists (locally and remotely)
+          git branch -D $BRANCH 2>/dev/null || true
+          git push origin --delete $BRANCH 2>/dev/null || true
+
+          # Create new release branch
           git checkout -b $BRANCH
 
           # Remove temporary changelog file


### PR DESCRIPTION
- When a manual run of the workflow fails, the release branch that was created should be deleted so the next run of the workflow is not impacted.