### PR TITLE
chore: Fix Release Workflow Bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,12 @@ jobs:
         run: yarn test --run
       - name: Build
         run: yarn build
+      - name: Get current version from package.json
+        id: current_version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
       - id: changelog
         name: Generate CHANGELOG
         uses: reearth/changelog-action@main
@@ -56,6 +62,7 @@ jobs:
           version: ${{ github.event.inputs.version == 'custom' && github.event.inputs.custom_version || github.event.inputs.version }}
           repo: ${{ github.repository }}
           latest: CHANGELOG_latest.md
+          from: v${{ steps.current_version.outputs.current }}
       - name: Upload latest CHANGELOG
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
## Fix Release Workflow to Use package.json Version for Changelog Generation

  This PR fixes a critical issue in the automated release workflow where changelog generation was skipping versions.

  ### 🐛 Problem

  The release workflow was using git tags to determine the version range for changelog generation. This caused several issues:

  1. **Chicken-and-egg problem**: Tags are created AFTER the release PR is merged, but the changelog is generated BEFORE
  2. **Skipped versions**: When generating the v1.19.0 changelog, it skipped v1.18.4 entirely and jumped from v1.19.0 to v1.16.1 in the CHANGELOG
  3. **Unreliable**: If tags are missing, delayed, or inconsistent, the changelog generation breaks

  **Example of the issue:**
  Current CHANGELOG.md:
  1.19.0 - 2025-11-07

  - Upgrade Cesium from 1.116.0 to 1.134.1

  v1.16.1 - 2022/03/20   <-- Missing v1.17.x, v1.18.x!


  ### ✅ Solution

  **Use `package.json` as the source of truth instead of git tags.**

  Added a new step that:
  1. Reads the current version from `package.json` (e.g., `1.19.0`)
  2. Passes it to the changelog action as the `from` parameter: `from: v1.19.0`
  3. Generates changelog from `v1.19.0` to `HEAD`

  **New workflow step:**
  ```yaml
  - name: Get current version from package.json
    id: current_version
    run: |
      CURRENT_VERSION=$(node -p "require('./package.json').version")
      echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
      echo "Current version: $CURRENT_VERSION"

  - name: Generate CHANGELOG
    uses: reearth/changelog-action@main
    with:
      version: ${{ ... }}
      repo: ${{ github.repository }}
      latest: CHANGELOG_latest.md
      from: v${{ steps.current_version.outputs.current }}  # <-- NEW

  📊 Benefits

  1. Consistent changelogs: Always includes all commits since the last merged release
  2. No skipped versions: Won't miss versions regardless of tag timing
  3. Reliable: Works even if tags are missing, delayed, or inconsistent
  4. Correct flow: package.json (source of truth) → changelog → version bump → tag (later)

  🔄 How It Works Now

  Example scenario:
  1. Current package.json version: 1.19.0
  2. Developer triggers workflow with "minor" bump
  3. Workflow:
    - ✅ Reads current version: 1.19.0
    - ✅ Generates changelog from v1.19.0 to HEAD
    - ✅ Bumps version to 1.20.0
    - ✅ Creates PR with both changes
  4. After PR is merged, create git tag v1.20.0 (manual or automated)

  🧪 Testing

  To test this fix:
  1. Merge this PR
  2. Trigger the release workflow from main branch
  3. Verify the generated changelog includes commits since the current package.json version
  4. Check that no versions are skipped in the CHANGELOG

  📝 Notes

  - This does not change the tagging process - tags should still be created after merging release PRs
  - Git tags are still useful for GitHub releases and npm publishing
  - This fix only affects how the changelog determines the version range

  🔗 Related

  - Fixes the issue where v1.18.4 was completely missing from the v1.19.0 changelog
  - Prevents future version skipping issues
