### PR TITLE
build!: fix react jsx-runtime not being externalized

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "type": "module",
   "description": "React component library for Cesium",
   "source": "./src/index.ts",
-  "main": "./dist/resium.umd.cjs",
+  "main": "./dist/resium.cjs",
   "module": "./dist/resium.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/resium.js",
-      "require": "./dist/resium.umd.cjs"
+      "require": "./dist/resium.cjs"
     }
   },
   "repository": "https://github.com/reearth/resium.git",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,16 +18,16 @@ export default defineConfig({
     lib: {
       entry: "src/index.ts",
       name: "Resium",
+      formats: ["es", "cjs"],
     },
     rolldownOptions: {
-      external: ["cesium", "react", "react-dom"],
-      output: {
-        globals: {
-          cesium: "Cesium",
-          react: "React",
-          "react-dom": "ReactDOM",
-        },
-      },
+      external: [
+        "cesium",
+        "react",
+        "react/jsx-runtime",
+        "react-dom",
+        "react-dom/client",
+      ],
     },
   },
   test: {


### PR DESCRIPTION
After Vite and Vite plugin updates in #747, library users using Rolldown started seeing the following client-side errors:

> Error: Calling 'require' for "react" in an environment that doesn't expose the 'require' function.

This was caused by `react/jsx-runtime` not being externalized during build, which emitted dynamic requires for react even in the ESM output.

Fixed by externalizing `react/jsx-runtime`. This required changing the output formats from the default `["es","umd"]` to `["es","cjs"]` as the `react/jsx-runtime` dependency does not have a globally named UMD variant for us to export AFAIK. Also added `react-dom/client` just in case, don't think it's strictly required right now though.

This however is a breaking change for consumers expecting to consume Resium as an UMD build instead of CJS, but I don't see any guidance in the docs for anyone to use Resium via `<script>` so maybe there are none.

Closes #753