### PR TITLE
chore: address post-merge review feedback on Cesium 1.140.0 PR

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,8 @@ export default [
       "dist",
       "examples",
       "coverage",
-      ".claude/**", // Git worktrees and Claude session files
+      ".worktrees/**", // Git worktrees
+      ".claude/**", // Claude session files (including .claude/worktrees/)
       "docs/**", // Docusaurus docs use CommonJS
       ".storybook/**", // Storybook config
       "**/*.stories.tsx", // Storybook stories

--- a/src/BufferPointCollection/BufferPointCollection.ts
+++ b/src/BufferPointCollection/BufferPointCollection.ts
@@ -70,6 +70,7 @@ const BufferPointCollection = createCesiumComponent<
   },
   cesiumProps,
   cesiumReadonlyProps,
+  setCesiumPropsAfterCreate: true,
 });
 
 export default BufferPointCollection;

--- a/src/BufferPolygonCollection/BufferPolygonCollection.ts
+++ b/src/BufferPolygonCollection/BufferPolygonCollection.ts
@@ -93,6 +93,7 @@ const BufferPolygonCollection = createCesiumComponent<
   },
   cesiumProps,
   cesiumReadonlyProps,
+  setCesiumPropsAfterCreate: true,
 });
 
 export default BufferPolygonCollection;

--- a/src/BufferPolylineCollection/BufferPolylineCollection.ts
+++ b/src/BufferPolylineCollection/BufferPolylineCollection.ts
@@ -73,6 +73,7 @@ const BufferPolylineCollection = createCesiumComponent<
   },
   cesiumProps,
   cesiumReadonlyProps,
+  setCesiumPropsAfterCreate: true,
 });
 
 export default BufferPolylineCollection;


### PR DESCRIPTION
## Summary

Follow-up to [#763](https://github.com/reearth/resium/pull/763). Addresses two Copilot review comments that landed after the PR was merged.

- **fix: apply initial cesiumProps on mount for Buffer*Collection components** — Without `setCesiumPropsAfterCreate`, initial values for `show`, `modelMatrix`, and `debugShowBoundingVolume` were never applied to the underlying Cesium primitive on first mount; they only took effect if the prop changed later. Matches the pattern used by `BillboardCollection`. Applies to `BufferPointCollection`, `BufferPolylineCollection`, and `BufferPolygonCollection`.
- **chore: add `.worktrees/**` to eslint ignores** — ESLint doesn't read `.gitignore`, so worktrees at the top-level `.worktrees/` path would still be traversed by `yarn lint`. Also split the inline comment so each pattern's purpose is clear.

## Test plan

- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — clean
- [x] `yarn vitest run` on the 3 affected Buffer*Collection test files — 4/4 pass
