### PR TITLE
fix(publish): activate npm via corepack instead of npm install -g

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,10 +51,16 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
-      - name: Upgrade npm to a Trusted-Publishing-capable version
+      - name: Activate npm via corepack
         # Trusted Publishing needs npm >=11.5.1; Node 22 ships npm 10.x.
+        # We cannot use `npm install -g npm@<version>` to upgrade because the
+        # bundled npm@10.x in some Node 22.x patch releases has a broken
+        # @npmcli/arborist tree (missing `promise-retry`) and crashes during
+        # any global install. corepack fetches a fresh npm binary directly,
+        # bypassing the broken self-upgrade path.
         run: |
-          npm install -g npm@latest
+          corepack enable npm
+          corepack prepare npm@11.5.1 --activate
           npm --version
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

Hot-fix for the publish workflow. The first attempt at the v1.21.1 release ([run](https://github.com/reearth/resium/actions/workflows/publish.yml)) failed at the npm-upgrade step:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
\`\`\`

Node 22.22.2's bundled npm@10.x has a broken \`@npmcli/arborist\` tree — it's missing the \`promise-retry\` transitive — so any \`npm install -g <anything>\` crashes inside its own dependency resolver before it can install. The bundled npm cannot fix itself.

## Fix

Use **corepack** to fetch a fresh npm binary directly, bypassing the buggy self-upgrade path entirely. Same approach used by [\`reearth/compressible\`](https://github.com/reearth/compressible/blob/main/.github/workflows/release.yml#L34-L46).

Pinned to \`npm@11.5.1\` — the minimum version required by npm Trusted Publishing. Pinning rather than \`@latest\` avoids future drift surprises.

## Confirmed no npm side effects

\`npm view resium@1.21.1\` returns 404 — the failed run never reached \`npm publish\`, so no tarball exists on the registry. The \`v1.21.1\` git tag will be deleted and re-created at the merge commit of this PR after it lands, then the publish workflow re-runs from scratch with the fix in place. \`package.json\` is already at \`1.21.1\` on main from the release PR, so the tag-version verify step will pass.

## Test plan

- [x] \`actionlint\` clean
- [ ] CI green
- [ ] After merge: retag \`v1.21.1\` → new Publish run → npm publish succeeds → \`resium@1.21.1\` lands on npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)