### PR TITLE
fix(core): update context for descendants when a parent is recreated

### DIFF
--- a/src/core/component.test.tsx
+++ b/src/core/component.test.tsx
@@ -269,6 +269,53 @@ describe("core/component", () => {
     });
   });
 
+  it("should recreate children with the new context when parent is recreated by a readonly prop change", async () => {
+    let n = 0;
+    const create1 = vi.fn(() => `parent${n++}`);
+    const create2 = vi.fn(() => "child");
+    const destroy2 = vi.fn();
+
+    const Parent = createCesiumComponent<string, { children?: ReactNode; recreate?: number }>({
+      name: "parent",
+      create: create1,
+      cesiumReadonlyProps: ["recreate"],
+      provide: (element): any => ({ parent: element }),
+    });
+
+    const Child = createCesiumComponent<string, Record<string, never>>({
+      name: "child",
+      create: create2,
+      destroy: destroy2,
+    });
+
+    const { rerender } = render(
+      <Parent recreate={0}>
+        <Child />
+      </Parent>,
+    );
+
+    await waitFor(() => {
+      expect(create1).toBeCalledTimes(1);
+      expect(create2).toHaveBeenLastCalledWith({ parent: "parent0" }, expect.anything(), null);
+    });
+
+    // Changing a readonly prop recreates the parent, which provides a new
+    // context (a new `parent` element). Children must tear down and re-create
+    // against it (issues #661 and #685) — exactly once, not repeatedly.
+    rerender(
+      <Parent recreate={1}>
+        <Child />
+      </Parent>,
+    );
+
+    await waitFor(() => {
+      expect(create1).toBeCalledTimes(2);
+      expect(create2).toBeCalledTimes(2);
+      expect(destroy2).toBeCalledTimes(1);
+      expect(create2).toHaveBeenLastCalledWith({ parent: "parent1" }, expect.anything(), null);
+    });
+  });
+
   it("should invoke onUpdate event when being dirty", () => {
     const cesiumElement = {
       foo: 0,

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -4,6 +4,7 @@ import {
   useRef,
   useImperativeHandle,
   useState,
+  useReducer,
   useCallback,
   useLayoutEffect,
   RefObject,
@@ -79,6 +80,10 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
   const prevProps = useRef<Props>({} as Props);
   const [mounted, setMounted] = useState(false);
   const mountedRef = useRef(false);
+  // Bumped after a recreation re-assigns `provided.current`, to force a render
+  // so the new context reaches consumers. `setMounted(true)` can't do this on
+  // its own: during a recreation `mounted` is already `true`, so it's a no-op.
+  const [, forceRender] = useReducer((c: number) => c + 1, 0);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef<State | undefined>(undefined);
   const eventManager = ctx?.[eventManagerContextKey];
@@ -161,7 +166,10 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
         mountReadyRef.current = mount();
       }
     },
-    [], // eslint-disable-line react-hooks/exhaustive-deps
+    // `ctx` is a dependency so that when a parent is recreated (a read-only
+    // prop change) and provides a new context, this callback closes over the
+    // new context instead of the stale one. See the layout effect below.
+    [ctx], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const mount = useCallback(async () => {
@@ -211,6 +219,8 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
         ...ctx,
         ...provide(element.current, ctx, props, stateRef.current),
       };
+      // Re-render so the freshly provided context propagates to consumers.
+      forceRender();
     }
 
     const em = useRootEvent
@@ -223,7 +233,7 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
     if (!unmountReadyRef.current) {
       setMounted(true);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [ctx]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const beforeUnmount = useCallback(() => {
     setMounted(false);
@@ -265,9 +275,13 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
     provided.current = undefined;
     stateRef.current = undefined;
     element.current = undefined;
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [ctx]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // To prevent re-execution by hot loader, execute only once
+  // Mount on first render, and re-run when `mount`/`unmount` change — which,
+  // thanks to their `[ctx]` dependency, happens when a parent is recreated and
+  // provides a new context. That tears down the stale Cesium element (attached
+  // to the destroyed parent) and recreates it against the new one, cascading
+  // down the tree. See issues #661 and #685.
   useLayoutEffect(() => {
     const run = async () => {
       if (unmountReadyRef.current) {


### PR DESCRIPTION
## Summary

Fixes #685 and #661: when a read-only prop changes, a component recreates its underlying Cesium element and provides a **new** context, but descendants kept referencing the **old** (destroyed) element.

Two root causes in `src/core/hooks.ts`:

1. `mount` / `unmount` / `updateProperties` were `useCallback(..., [])`, so they closed over the **initial** `ctx`. The mount layout effect (deps `[mount, unmount, beforeUnmount]`) therefore never re-ran when the provided context changed.
2. Re-assigning `provided.current` after a recreation didn't trigger a render — `setMounted(true)` is a no-op while `mounted` is already `true` — so the new context never reached `<CesiumContext.Provider>`.

### Fix

- Add `ctx` to the dependency arrays of `mount` / `unmount` / `updateProperties`. The context object identity is stable except when a parent is recreated, so the layout effect now re-runs exactly when needed: it tears down the stale element and recreates it against the new parent, cascading down the tree.
- Add a `forceRender` (a `useReducer` bump) right after `provided.current` is reassigned, so the freshly provided context propagates to consumers.

### Behavior verified (new unit test)

On a parent recreation the child is torn down once and recreated once against the new context — no double-creation:

```
CREATE(child, {parent: parent0})   // initial
DESTROY(child, {parent: parent0})  // old torn down
CREATE(child, {parent: parent1})   // recreated against new parent
```

## Test plan

- [x] New regression test in `src/core/component.test.tsx` (child re-creates with the new context; create×2, destroy×1)
- [x] Full unit suite passes (102 tests)
- [x] `yarn type` and `yarn lint` clean