### PR TITLE
docs: clarify cesiumElement ref timing, useCesium scope, and tileset zoom

### DIFF
--- a/docs/docs/03-guide.md
+++ b/docs/docs/03-guide.md
@@ -186,6 +186,20 @@ To know what is a Cesium element of each component, refer to "Cesium element" in
 
 Note: `cesiumElement` property in the ref object can be `undefined`: e.g. when an initialization error is occurred. Please check if it's not `undefined` when using `cesiumElement`.
 
+:::caution
+
+**Why is `cesiumElement` `undefined` right after rendering?**
+
+A Cesium element is **not** created during the first render, and for root components such as `Viewer` the initialization is even asynchronous. So `ref.current.cesiumElement` is `undefined` (or the ref itself is `null`) until initialization finishes. Once the element is ready, Resium triggers a re-render and the ref is populated.
+
+In practice this means:
+
+- Read `cesiumElement` inside `useEffect`, event handlers, or other callbacks — **not** during render.
+- Do not assume it is available synchronously right after `<Viewer />` is mounted.
+- If you need to react to the element becoming available, copy it into state from an effect, or read it from a child component with the [`useCesium`](#accessing-the-cesium-element-from-descendant-components) hook.
+
+:::
+
 ### Way 1: useRef hooks (function component)
 
 Function component:
@@ -335,6 +349,31 @@ class ExampleComponent extends Component {
   }
 }
 ```
+
+## Accessing the Cesium element from descendant components
+
+Instead of a `ref`, components rendered **inside** `Viewer` / `CesiumWidget` can read the current Cesium objects from React context with the `useCesium` hook:
+
+```jsx
+import { Viewer, useCesium } from "resium";
+
+const Inner = () => {
+  const { viewer, scene, camera } = useCesium();
+  // `viewer` is Cesium's Viewer, available because this runs inside <Viewer>.
+  // DO SOMETHING
+  return null;
+};
+
+const ExampleComponent = () => (
+  <Viewer>
+    <Inner />
+  </Viewer>
+);
+```
+
+`useCesium` reads the closest Resium context, so it returns Cesium objects **only** when it is called from a component mounted **under** a root component (`Viewer` or `CesiumWidget`).
+
+Calling `useCesium` in the **same** component that renders `<Viewer>` (i.e. the parent) returns an empty object, because the context provider lives inside `Viewer`. In that case the values will always be `undefined`. To fix this, move the logic into a child component as shown above, or use a `ref` instead.
 
 ## Limitations
 

--- a/scripts/generator/parser.mts
+++ b/scripts/generator/parser.mts
@@ -149,6 +149,11 @@ function parseDocComment(node: Node): DocComment | undefined {
           scope: c.replace(/^ *?@scope/, "").trim(),
         };
       }
+      if (/^ *?@example/.test(c)) {
+        return {
+          example: c.replace(/^ *?@example/, "").trim(),
+        };
+      }
       if (/^ *?@ignore/.test(c)) {
         return {
           ignored: true,

--- a/scripts/generator/renderer.mts
+++ b/scripts/generator/renderer.mts
@@ -21,6 +21,14 @@ ${
 ${doc.scope}
 `
     : ""
+}${
+  doc.example
+    ? `
+## Example
+
+${doc.example}
+`
+    : ""
 }
 ## Properties
 

--- a/scripts/generator/types.mts
+++ b/scripts/generator/types.mts
@@ -11,6 +11,7 @@ export type DocComment = {
   cesiumElement?: string;
   summary?: string;
   scope?: string;
+  example?: string;
   ignored?: boolean;
 };
 

--- a/src/Cesium3DTileset/Cesium3DTileset.ts
+++ b/src/Cesium3DTileset/Cesium3DTileset.ts
@@ -27,6 +27,38 @@ Inside [Viewer](/components/Viewer) or [CesiumWidget](/components/CesiumWidget) 
 A Cesium3DTileset object will be attached to the PrimitiveCollection of the Viewer or CesiumWidget.
 */
 
+/*
+@example
+A `Cesium3DTileset` is loaded asynchronously, so it has no bounding sphere yet during the first render. To fly/zoom the camera to the tileset once it is completely loaded, use the `onReady` callback, which receives the loaded `Cesium3DTileset`:
+
+```tsx
+import { useRef } from "react";
+import { Viewer as CesiumViewer } from "cesium";
+import { Viewer, Cesium3DTileset, CesiumComponentRef } from "resium";
+
+const ExampleComponent = () => {
+  const ref = useRef<CesiumComponentRef<CesiumViewer>>(null);
+
+  return (
+    <Viewer full ref={ref}>
+      <Cesium3DTileset
+        url="./tileset/tileset.json"
+        onReady={tileset => {
+          ref.current?.cesiumElement?.zoomTo(tileset);
+        }}
+      />
+    </Viewer>
+  );
+};
+```
+
+:::note
+
+The deprecated `Cesium3DTileset.readyPromise` has been removed from CesiumJS, so it no longer resolves. Use the `onReady` prop instead.
+
+:::
+*/
+
 export type Cesium3DTilesetCesiumProps = PickCesiumProps<CesiumCesium3DTileset, typeof cesiumProps>;
 
 export type Cesium3DTilesetCesiumReadonlyProps = PickCesiumProps<


### PR DESCRIPTION
## What

Documentation-only changes addressing recurring questions in issues.

### Guide (`docs/docs/03-guide.md`)
- Explain that `cesiumElement` is populated **asynchronously** — it is `undefined` right after the first render and should be read inside effects/callbacks, not during render. (#619, #662)
- Add a section documenting the `useCesium` hook and the key gotcha: it only returns Cesium objects when called from a component mounted **inside** `Viewer`/`CesiumWidget`, not from the parent that renders `<Viewer>`. (#619, #662)

### Doc generator + Cesium3DTileset (#696)
- Add an `@example` tag to the component doc generator (`parser`/`renderer`/`types`) so component pages can carry a usage example.
- Use it on `Cesium3DTileset` to show zooming to the tileset via `onReady` + `ref.cesiumElement.zoomTo(tileset)`, and note that `Cesium3DTileset.readyPromise` was removed from CesiumJS.

## Notes
- Docs only; no library/runtime code changes (the only `src/` change is a doc comment).
- Verified `yarn docs:generate` + Docusaurus build pass locally.
- Merging to `main` triggers the existing docs deploy to resium.reearth.io.