### PR TITLE
fix: resolve real bugs (Globe terrain, StrictMode events, tileset url, Polyline material, Clock timeline)

### DIFF
--- a/src/Cesium3DTileset/Cesium3DTileset.ts
+++ b/src/Cesium3DTileset/Cesium3DTileset.ts
@@ -141,7 +141,14 @@ export const cesiumEventProps = {
   onTileVisible: "tileVisible",
 } as const;
 
-export const otherProps = ["onReady", "onError", "url"] as const;
+export const otherProps = ["onReady", "onError"] as const;
+
+// `url` is consumed directly inside `create()` (it is not a real Cesium property),
+// but it is treated as a read-only prop so that changing it at runtime makes the
+// core destroy and recreate the tileset (re-running `fromUrl`). It is kept out of
+// the `Cesium3DTilesetCesiumReadonlyProps` type because it does not exist on the
+// Cesium class.
+const cesiumReadonlyPropsWithUrl = [...cesiumReadonlyProps, "url"] as const;
 
 const Cesium3DTileset = createCesiumComponent<CesiumCesium3DTileset, Cesium3DTilesetProps>({
   name: "Cesium3DTileset",
@@ -187,7 +194,7 @@ const Cesium3DTileset = createCesiumComponent<CesiumCesium3DTileset, Cesium3DTil
     }
   },
   cesiumProps,
-  cesiumReadonlyProps,
+  cesiumReadonlyProps: cesiumReadonlyPropsWithUrl,
   cesiumEventProps,
   otherProps,
   useCommonEvent: true,

--- a/src/Clock/Clock.stories.tsx
+++ b/src/Clock/Clock.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { JulianDate, ClockRange, ClockStep } from "cesium";
+import { JulianDate, ClockRange, ClockStep, Viewer as CesiumViewer } from "cesium";
+import { useEffect, useMemo, useRef } from "react";
 
+import { CesiumComponentRef } from "../core";
 import Globe from "../Globe";
 import Viewer from "../Viewer";
 
@@ -14,18 +16,33 @@ export default {
 } as Meta;
 
 export const Basic: Story = {
-  render: () => (
-    <Viewer full>
-      <Globe enableLighting />
-      <Clock
-        startTime={JulianDate.fromIso8601("2013-12-25")}
-        currentTime={JulianDate.fromIso8601("2013-12-25")}
-        stopTime={JulianDate.fromIso8601("2013-12-26")}
-        clockRange={ClockRange.LOOP_STOP} // loop when we hit the end time
-        clockStep={ClockStep.SYSTEM_CLOCK_MULTIPLIER}
-        multiplier={4000} // how much time to advance each tick
-        shouldAnimate // Animation on by default
-      />
-    </Viewer>
-  ),
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const ref = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const startTime = useMemo(() => JulianDate.fromIso8601("2013-12-25"), []);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const stopTime = useMemo(() => JulianDate.fromIso8601("2013-12-26"), []);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      // Zoom the bottom Timeline widget to the clock's time range so it is bound to the clock.
+      ref.current?.cesiumElement?.timeline?.zoomTo(startTime, stopTime);
+    }, [startTime, stopTime]);
+
+    return (
+      <Viewer full ref={ref}>
+        <Globe enableLighting />
+        <Clock
+          startTime={startTime}
+          currentTime={startTime}
+          stopTime={stopTime}
+          clockRange={ClockRange.LOOP_STOP} // loop when we hit the end time
+          clockStep={ClockStep.SYSTEM_CLOCK_MULTIPLIER}
+          multiplier={4000} // how much time to advance each tick
+          shouldAnimate // Animation on by default
+        />
+      </Viewer>
+    );
+  },
 };

--- a/src/Globe/Globe.ts
+++ b/src/Globe/Globe.ts
@@ -110,7 +110,8 @@ const otherProps = ["terrainProvider"] as const;
 const Globe = createCesiumComponent<CesiumGlobe, GlobeProps>({
   name: "Globe",
   create: context => context.scene?.globe,
-  update: async (elm, props) => {
+  update: async (elm, props, prevProps) => {
+    if (props.terrainProvider === prevProps.terrainProvider) return;
     const maybePromiseTerrainProvider = props.terrainProvider;
     let resultTerrainProvider: TerrainProvider;
     if (isPromise(maybePromiseTerrainProvider)) {

--- a/src/Polyline/Polyline.ts
+++ b/src/Polyline/Polyline.ts
@@ -1,3 +1,4 @@
+import { Color, Material as CesiumMaterial } from "cesium";
 import type {
   Material,
   Cartesian3,
@@ -51,11 +52,38 @@ const cesiumProps = [
   "width",
 ] as const;
 
-const Polyline = createCesiumComponent<CesiumPolyline, PolylineProps>({
+// Cesium's `PolylineCollection.remove` calls `Polyline._destroy`, which
+// unconditionally destroys the polyline's current `material`. When the user
+// passes their own `Material` instance via the `material` prop, Cesium destroys
+// that user-owned instance on unmount. Under React StrictMode (mount → unmount
+// → remount), the throwaway first mount destroys the shared material, and the
+// real second mount then reuses an already-destroyed material, throwing
+// "This object was destroyed, i.e., destroy() was called." (#602)
+//
+// resium creates the polyline but does not own the `Material` passed as a prop,
+// so it must not let Cesium destroy it. Before removing the polyline we swap in
+// a throwaway material so Cesium destroys that instead, leaving the user's
+// material intact.
+type PolylineState = { userMaterial: boolean };
+
+const Polyline = createCesiumComponent<CesiumPolyline, PolylineProps, PolylineState>({
   name: "Polyline",
-  create: (context, props) => context.polylineCollection?.add(props),
-  destroy(element, context) {
+  create: (context, props) => {
+    const element = context.polylineCollection?.add(props);
+    if (!element) return undefined;
+    return [element, { userMaterial: !!props.material }];
+  },
+  destroy(element, context, _wrapperRef, state) {
     if (context.polylineCollection && !context.polylineCollection.isDestroyed()) {
+      // Detach the user-owned material so Cesium destroys a throwaway instead.
+      if (state?.userMaterial) {
+        const material = element.material;
+        if (material && !material.isDestroyed()) {
+          element.material = CesiumMaterial.fromType(CesiumMaterial.ColorType, {
+            color: new Color(1.0, 1.0, 1.0, 1.0),
+          });
+        }
+      }
       context.polylineCollection.remove(element);
     }
   },

--- a/src/core/component.test.tsx
+++ b/src/core/component.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { Event } from "cesium";
 import type { ReactNode } from "react";
-import { createRef } from "react";
+import { createRef, StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi, vitest } from "vitest";
 
 import type { CesiumComponentRef } from "./component";
@@ -118,6 +118,39 @@ describe("core/component", () => {
 
     await waitFor(() => {
       expect(cesiumElement.foo).toBe(10);
+    });
+  });
+
+  it("should re-attach cesium events after a StrictMode remount with setCesiumPropsAfterCreate", async () => {
+    // Regression test for #736 / #680: under StrictMode the component is mounted,
+    // unmounted, then remounted. For setCesiumPropsAfterCreate components the
+    // second mount goes through updateProperties(initialProps), which diffs
+    // against prevProps. If prevProps is not reset on unmount, the stable event
+    // handler reference is treated as unchanged and the listener is never
+    // re-attached, leaving numberOfListeners at 0.
+    const cesiumElement = {
+      hoge: new Event(),
+    };
+
+    // A stable handler reference shared across mounts (as in real usage where
+    // the same callback prop is passed on every render).
+    const handler = () => {};
+
+    const Component = createCesiumComponent<typeof cesiumElement, { bar?: () => void }>({
+      name: "test",
+      create: () => cesiumElement,
+      cesiumEventProps: { bar: "hoge" },
+      setCesiumPropsAfterCreate: true,
+    });
+
+    render(
+      <StrictMode>
+        <Component bar={handler} />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(cesiumElement.hoge.numberOfListeners).toBe(1);
     });
   });
 

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -275,6 +275,12 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
     }
 
     attachedEvents.current = {};
+    // Reset prevProps so the next mount's updateProperties re-detects every prop
+    // (including stable event-handler references) as newly added and re-attaches
+    // them. Without this, after a StrictMode unmount+remount, the diff in
+    // updateProperties would see no change and events would not be re-attached
+    // (#736, #680).
+    prevProps.current = {} as Props;
     provided.current = undefined;
     stateRef.current = undefined;
     element.current = undefined;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,14 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
-    exclude: [...configDefaults.exclude, "docs/**/*", "examples/**/*"],
+    exclude: [
+      ...configDefaults.exclude,
+      "**/docs/**",
+      "**/examples/**",
+      // Ignore git worktrees created by AI agents (e.g. under .claude/worktrees),
+      // otherwise their nested copies of examples/docs get picked up as tests.
+      "**/.claude/**",
+    ],
     setupFiles: ["src/test/setup.ts"],
     coverage: {
       reporter: ["text", "json"],


### PR DESCRIPTION
## Summary
Fixes several confirmed bugs, verified against the current source. (The `GooglePhotorealistic3DTileset` component has been split out into its own PR #781.)

### Bug fixes
- **fix(core): reset `prevProps` on unmount** so event listeners re-attach after a React StrictMode remount. `unmount` cleared `attachedEvents` but not `prevProps`, so `setCesiumPropsAfterCreate` components (Camera, Clock) saw "no change" on the second mount and never re-bound events. Closes **#736**, **#680**. *(adds a regression test)*
- **fix(Globe): only update `terrainProvider` when the prop actually changes.** The `update` callback assigned `elm.terrainProvider` on every prop change, wiping terrain when unset and needlessly recomputing when set. Now compares against `prevProps`. Closes **#692**.
- **fix(Cesium3DTileset): recreate the tileset when `url` changes.** `url` was an `otherProp`, so runtime changes were ignored; it now triggers recreation via `fromUrl`. Closes **#694**.
- **fix(Polyline): don't destroy a user-owned `material` on unmount.** Cesium's `PolylineCollection.remove` unconditionally destroys the polyline's material; under StrictMode this killed a shared/memoized `Material`, breaking the real remount ("This object was destroyed"). Resium now detaches a user-supplied material before removal. Closes **#602**.
- **fix(Clock): zoom the Timeline to the clock range in the example.** The `timeline` widget lives on `Viewer` (not `CesiumWidget`), so this was an example gap, not a component bug — the story now demonstrates `timeline.zoomTo(start, stop)` via a ref. Closes **#620**.

### Tooling
- **test: exclude nested `examples`/`docs` and `.claude` worktrees from vitest** (path-agnostic globs) so agent git worktrees never pollute the test run.

## Verification
- `npx tsc --noEmit` ✅ / `npx eslint .` ✅ / `npx vitest run` ✅ (103 tests) / `npx vite build` ✅