### PR TITLE
feat: add GooglePhotorealistic3DTileset component

### DIFF
--- a/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.stories.tsx
+++ b/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.stories.tsx
@@ -1,0 +1,43 @@
+import { action } from "storybook/actions";
+import { Meta, StoryObj } from "@storybook/react";
+import { Viewer as CesiumViewer } from "cesium";
+import { useRef } from "react";
+
+import { CesiumComponentRef } from "../core";
+import { events } from "../core/storybook";
+import Viewer from "../Viewer";
+
+import GooglePhotorealistic3DTileset from "./GooglePhotorealistic3DTileset";
+
+type Story = StoryObj<typeof GooglePhotorealistic3DTileset>;
+
+export default {
+  title: "GooglePhotorealistic3DTileset",
+  component: GooglePhotorealistic3DTileset,
+} as Meta;
+
+// An API key may be required to load Google Photorealistic 3D Tiles.
+// Set it globally via `Cesium.GoogleMaps.defaultApiKey` or pass the `key` prop.
+export const Basic: Story = {
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const ref = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    return (
+      <Viewer full ref={ref}>
+        <GooglePhotorealistic3DTileset
+          {...args}
+          onAllTilesLoad={action("onAllTilesLoad")}
+          onInitialTilesLoad={action("onInitialTilesLoad")}
+          onTileFailed={action("onTileFailed")}
+          onTileLoad={action("onTileLoad")}
+          onTileUnload={action("onTileUnload")}
+          onReady={tileset => {
+            ref.current?.cesiumElement?.zoomTo(tileset);
+          }}
+          onError={action("onError")}
+          {...events}
+        />
+      </Viewer>
+    );
+  },
+};

--- a/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.stories.tsx
+++ b/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.stories.tsx
@@ -17,7 +17,7 @@ export default {
 } as Meta;
 
 // An API key may be required to load Google Photorealistic 3D Tiles.
-// Set it globally via `Cesium.GoogleMaps.defaultApiKey` or pass the `key` prop.
+// Set it globally via `Cesium.GoogleMaps.defaultApiKey` or pass the `apiKey` prop.
 export const Basic: Story = {
   render: args => {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.ts
+++ b/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.ts
@@ -24,7 +24,8 @@ This component asynchronously creates a Cesium3DTileset via Cesium's
 PrimitiveCollection of the Viewer or CesiumWidget.
 
 An API key may be required. Set it globally via `Cesium.GoogleMaps.defaultApiKey`,
-or pass it through the `key` prop.
+or pass it through the `apiKey` prop. (It is named `apiKey`, not `key`, because
+`key` is a reserved React prop and would never reach the component.)
 
 ```jsx
 import { useRef } from "react";
@@ -79,8 +80,8 @@ export type GooglePhotorealistic3DTilesetOtherProps = EventProps<Cesium3DTileFea
   onReady?: (tileset: CesiumCesium3DTileset) => void;
   /** Calls when an error occurs while creating the tile set. */
   onError?: (err: unknown) => void;
-  /** The API key to access Google Photorealistic 3D Tiles. If not provided, uses GoogleMaps.defaultApiKey. */
-  key?: string;
+  /** The API key to access Google Photorealistic 3D Tiles. If not provided, uses GoogleMaps.defaultApiKey. (Named `apiKey` because `key` is reserved by React.) */
+  apiKey?: string;
   /** Whether to use the tiles only with the Google geocoder. */
   onlyUsingWithGoogleGeocoder?: true;
 };
@@ -175,7 +176,7 @@ export const cesiumEventProps = {
   onTileVisible: "tileVisible",
 } as const;
 
-export const otherProps = ["onReady", "onError", "key", "onlyUsingWithGoogleGeocoder"] as const;
+export const otherProps = ["onReady", "onError", "apiKey", "onlyUsingWithGoogleGeocoder"] as const;
 
 const GooglePhotorealistic3DTileset = createCesiumComponent<
   CesiumCesium3DTileset,
@@ -185,10 +186,10 @@ const GooglePhotorealistic3DTileset = createCesiumComponent<
   async create(context, props) {
     if (!context.primitiveCollection) return;
 
-    const { key, onlyUsingWithGoogleGeocoder } = props;
+    const { apiKey, onlyUsingWithGoogleGeocoder } = props;
     const apiOptions: { key?: string; onlyUsingWithGoogleGeocoder?: true } = {};
-    if (key !== undefined) {
-      apiOptions.key = key;
+    if (apiKey !== undefined) {
+      apiOptions.key = apiKey;
     }
     if (onlyUsingWithGoogleGeocoder !== undefined) {
       apiOptions.onlyUsingWithGoogleGeocoder = onlyUsingWithGoogleGeocoder;

--- a/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.ts
+++ b/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.ts
@@ -1,0 +1,233 @@
+import type {
+  Cesium3DTileFeature,
+  Cesium3DTile,
+  Cesium3DTileset as CesiumCesium3DTileset} from "cesium";
+import {
+  createGooglePhotorealistic3DTileset,
+} from "cesium";
+
+import type {
+  EventProps,
+  PickCesiumProps,
+  ConstructorOptions,
+  Merge} from "../core";
+import {
+  createCesiumComponent,
+} from "../core";
+
+/*
+@summary
+`GooglePhotorealistic3DTileset` provides Google Maps Photorealistic 3D Tiles.
+
+This component asynchronously creates a Cesium3DTileset via Cesium's
+`createGooglePhotorealistic3DTileset` factory and attaches it to the
+PrimitiveCollection of the Viewer or CesiumWidget.
+
+An API key may be required. Set it globally via `Cesium.GoogleMaps.defaultApiKey`,
+or pass it through the `key` prop.
+
+```jsx
+import { useRef } from "react";
+import { Viewer as CesiumViewer, GoogleMaps } from "cesium";
+import { Viewer, GooglePhotorealistic3DTileset, CesiumComponentRef } from "resium";
+
+GoogleMaps.defaultApiKey = "your_google_api_key";
+
+const App = () => {
+  const ref = useRef<CesiumComponentRef<CesiumViewer>>(null);
+  return (
+    <Viewer full ref={ref}>
+      <GooglePhotorealistic3DTileset
+        onReady={tileset => {
+          ref.current?.cesiumElement?.zoomTo(tileset);
+        }}
+      />
+    </Viewer>
+  );
+};
+```
+*/
+
+/*
+@scope
+Inside [Viewer](/components/Viewer) or [CesiumWidget](/components/CesiumWidget) component.
+A Cesium3DTileset object will be attached to the PrimitiveCollection of the Viewer or CesiumWidget.
+*/
+
+export type GooglePhotorealistic3DTilesetCesiumProps = PickCesiumProps<
+  CesiumCesium3DTileset,
+  typeof cesiumProps
+>;
+
+export type GooglePhotorealistic3DTilesetCesiumReadonlyProps = PickCesiumProps<
+  Merge<CesiumCesium3DTileset, ConstructorOptions<typeof CesiumCesium3DTileset>>,
+  typeof cesiumReadonlyProps
+>;
+
+export type GooglePhotorealistic3DTilesetCesiumEvents = {
+  onAllTilesLoad?: () => void;
+  onInitialTilesLoad?: () => void;
+  onLoadProgress?: (numberOfPendingRequests: number, numberOfTilesProcessing: number) => void;
+  onTileFailed?: (error: any) => void;
+  onTileLoad?: (tile: Cesium3DTile) => void;
+  onTileUnload?: (tile: Cesium3DTile) => void;
+  onTileVisible?: (tile: Cesium3DTile) => void;
+};
+
+export type GooglePhotorealistic3DTilesetOtherProps = EventProps<Cesium3DTileFeature> & {
+  /** Calls when the tile set is completely loaded. */
+  onReady?: (tileset: CesiumCesium3DTileset) => void;
+  /** Calls when an error occurs while creating the tile set. */
+  onError?: (err: unknown) => void;
+  /** The API key to access Google Photorealistic 3D Tiles. If not provided, uses GoogleMaps.defaultApiKey. */
+  key?: string;
+  /** Whether to use the tiles only with the Google geocoder. */
+  onlyUsingWithGoogleGeocoder?: true;
+};
+
+export type GooglePhotorealistic3DTilesetProps = GooglePhotorealistic3DTilesetCesiumProps &
+  GooglePhotorealistic3DTilesetCesiumReadonlyProps &
+  GooglePhotorealistic3DTilesetCesiumEvents &
+  GooglePhotorealistic3DTilesetOtherProps;
+
+const cesiumProps = [
+  "show",
+  "modelMatrix",
+  "shadows",
+  "maximumScreenSpaceError",
+  "cullRequestsWhileMoving",
+  "cullRequestsWhileMovingMultiplier",
+  "preloadWhenHidden",
+  "preloadFlightDestinations",
+  "preferLeaves",
+  "progressiveResolutionHeightFraction",
+  "foveatedScreenSpaceError",
+  "foveatedConeSize",
+  "foveatedMinimumScreenSpaceErrorRelaxation",
+  "foveatedInterpolationCallback",
+  "foveatedTimeDelay",
+  "dynamicScreenSpaceError",
+  "dynamicScreenSpaceErrorDensity",
+  "dynamicScreenSpaceErrorFactor",
+  "dynamicScreenSpaceErrorHeightFalloff",
+  "skipLevelOfDetail",
+  "baseScreenSpaceError",
+  "skipScreenSpaceErrorFactor",
+  "skipLevels",
+  "immediatelyLoadDesiredLevelOfDetail",
+  "loadSiblings",
+  "clippingPlanes",
+  "clippingPolygons",
+  "lightColor",
+  "colorBlendAmount",
+  "colorBlendMode",
+  "debugFreezeFrame",
+  "debugColorizeTiles",
+  "debugWireframe",
+  "debugShowBoundingVolume",
+  "debugShowContentBoundingVolume",
+  "debugShowViewerRequestVolume",
+  "debugShowGeometricError",
+  "debugShowRenderingStatistics",
+  "debugShowMemoryUsage",
+  "debugShowUrl",
+  "style",
+  "backFaceCulling",
+  "showOutline",
+  "vectorClassificationOnly",
+  "vectorKeepDecodedPositions",
+  "splitDirection",
+  "customShader",
+  "imageBasedLighting",
+  "showCreditsOnScreen",
+  "featureIdLabel",
+  "instanceFeatureIdLabel",
+  "outlineColor",
+  "cacheBytes",
+  "maximumCacheOverflowBytes",
+  "enableCollision",
+] as const;
+
+const cesiumReadonlyProps = [
+  "asynchronouslyLoadImagery",
+  "classificationType",
+  "cullWithChildrenBounds",
+  "debugHeatmapTilePropertyName",
+  "ellipsoid",
+  "enableDebugWireframe",
+  "heightReference",
+  "modelUpAxis",
+  "modelForwardAxis",
+  "projectTo2D",
+  "enableShowOutline",
+  "enablePick",
+  "environmentMapOptions",
+  "scene",
+] as const;
+
+export const cesiumEventProps = {
+  onAllTilesLoad: "allTilesLoaded",
+  onInitialTilesLoad: "initialTilesLoaded",
+  onLoadProgress: "loadProgress",
+  onTileFailed: "tileFailed",
+  onTileLoad: "tileLoad",
+  onTileUnload: "tileUnload",
+  onTileVisible: "tileVisible",
+} as const;
+
+export const otherProps = ["onReady", "onError", "key", "onlyUsingWithGoogleGeocoder"] as const;
+
+const GooglePhotorealistic3DTileset = createCesiumComponent<
+  CesiumCesium3DTileset,
+  GooglePhotorealistic3DTilesetProps
+>({
+  name: "GooglePhotorealistic3DTileset",
+  async create(context, props) {
+    if (!context.primitiveCollection) return;
+
+    const { key, onlyUsingWithGoogleGeocoder } = props;
+    const apiOptions: { key?: string; onlyUsingWithGoogleGeocoder?: true } = {};
+    if (key !== undefined) {
+      apiOptions.key = key;
+    }
+    if (onlyUsingWithGoogleGeocoder !== undefined) {
+      apiOptions.onlyUsingWithGoogleGeocoder = onlyUsingWithGoogleGeocoder;
+    }
+
+    let element;
+    try {
+      element = await createGooglePhotorealistic3DTileset(apiOptions, props);
+      props.onReady?.(element);
+    } catch (e) {
+      props.onError?.(e);
+      return;
+    }
+
+    if (props.colorBlendAmount) {
+      element.colorBlendAmount = props.colorBlendAmount;
+    }
+    if (props.colorBlendMode) {
+      element.colorBlendMode = props.colorBlendMode;
+    }
+    if (props.style) {
+      element.style = props.style;
+    }
+    context.primitiveCollection.add(element);
+    return element;
+  },
+  destroy(element, context) {
+    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
+      context.primitiveCollection.remove(element);
+    }
+    if (!element.isDestroyed()) {
+      element.destroy();
+    }
+  },
+  cesiumProps,
+  cesiumReadonlyProps,
+  cesiumEventProps,
+  otherProps,
+  useCommonEvent: true,
+});
+
+export default GooglePhotorealistic3DTileset;

--- a/src/GooglePhotorealistic3DTileset/index.ts
+++ b/src/GooglePhotorealistic3DTileset/index.ts
@@ -1,0 +1,4 @@
+export {
+  default,
+  type GooglePhotorealistic3DTilesetProps,
+} from "./GooglePhotorealistic3DTileset";

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,10 @@ export {
   type Google2DImageryProviderProps,
 } from "./Google2DImageryProvider";
 export {
+  default as GooglePhotorealistic3DTileset,
+  type GooglePhotorealistic3DTilesetProps,
+} from "./GooglePhotorealistic3DTileset";
+export {
   default as GroundPolylinePrimitive,
   type GroundPolylinePrimitiveProps,
 } from "./GroundPolylinePrimitive";


### PR DESCRIPTION
## Summary
Adds a `GooglePhotorealistic3DTileset` component wrapping CesiumJS's `createGooglePhotorealistic3DTileset`. It creates the Google Photorealistic 3D Tiles tileset asynchronously and attaches the resulting `Cesium3DTileset` to the Viewer/CesiumWidget primitive collection — analogous to the existing `Cesium3DTileset` component, minus `url` (the factory provides Google's tileset).

Addresses **#600**.

## Details
- New component `src/GooglePhotorealistic3DTileset/` (+ story + index).
- Exposes `onReady(tileset)` / `onError(err)`, the API options (`key`, `onlyUsingWithGoogleGeocoder`), and the usual Cesium3DTileset display props/events.
- An API key may be required (`Cesium.GoogleMaps.defaultApiKey`).
- Exported from `src/index.ts`; the doc generator will produce its page on the next docs build.

## Verification
- `npx tsc --noEmit` ✅ / `npx eslint` ✅

## Note
Named `GooglePhotorealistic3DTileset` to match Cesium's `createGooglePhotorealistic3DTileset` factory. Happy to rename if you'd prefer something shorter.