### PR TITLE
fix: ownership/destroy bugs (clippingPlanes/clippingPolygons, composite stages) + onSelectedEntityChange type

### DIFF
--- a/src/Cesium3DTileset/Cesium3DTileset.test.ts
+++ b/src/Cesium3DTileset/Cesium3DTileset.test.ts
@@ -1,10 +1,11 @@
 import type { Cesium3DTileset } from "cesium";
 import type { TypeEqual } from "ts-expect";
 import { expectType } from "ts-expect";
-import { it } from "vitest";
+import { expect, it, vi } from "vitest";
 
 import type { UnusedCesiumProps, Merge, ConstructorOptions } from "../core";
 
+import { detachUserOwnedClipping } from "./Cesium3DTileset";
 import type {
   Cesium3DTilesetProps,
   cesiumEventProps,
@@ -24,3 +25,22 @@ type IgnoredProps = "pointCloudShading";
 expectType<TypeEqual<never, UnusedProps>>(true);
 
 it("should be compiled", () => {});
+
+it("detaches user-owned clippingPlanes/clippingPolygons without destroying them", () => {
+  // Mimics the private references Cesium3DTileset.destroy() would destroy.
+  const clippingPlanes = { destroy: vi.fn() };
+  const clippingPolygons = { destroy: vi.fn() };
+  const element = {
+    _clippingPlanes: clippingPlanes,
+    _clippingPolygons: clippingPolygons,
+  } as unknown as Cesium3DTileset;
+
+  detachUserOwnedClipping(element);
+
+  // References are nulled so Cesium's destroy cascade has nothing to destroy.
+  expect((element as any)._clippingPlanes).toBeUndefined();
+  expect((element as any)._clippingPolygons).toBeUndefined();
+  // The user-owned collections themselves must not be destroyed by us.
+  expect(clippingPlanes.destroy).not.toBeCalled();
+  expect(clippingPolygons.destroy).not.toBeCalled();
+});

--- a/src/Cesium3DTileset/Cesium3DTileset.ts
+++ b/src/Cesium3DTileset/Cesium3DTileset.ts
@@ -143,6 +143,31 @@ export const cesiumEventProps = {
 
 export const otherProps = ["onReady", "onError", "url"] as const;
 
+/**
+ * `clippingPlanes` and `clippingPolygons` are user-supplied props. Cesium's
+ * `Cesium3DTileset.destroy()` unconditionally destroys these collections, and
+ * assigning them via the public setter would also destroy them (the setter
+ * calls `ClippingPlaneCollection.setOwner`, which destroys the previously owned
+ * collection). Cesium only populates the private `_clippingPlanes` /
+ * `_clippingPolygons` references when the user passed a collection (it creates
+ * no internal defaults), so we detach them by nulling the private references
+ * directly before `destroy()`, leaving the destroy cascade with nothing to
+ * destroy. This prevents resium from destroying Cesium objects it received as
+ * props (same class of bug as #602), which would break reuse under React
+ * StrictMode.
+ *
+ * See @cesium/engine Cesium3DTileset.js (constructor ~L823-839, destroy
+ * ~L3615-3617) and ClippingPlaneCollection.setOwner (~L661-683).
+ */
+export const detachUserOwnedClipping = (element: CesiumCesium3DTileset): void => {
+  const e = element as unknown as {
+    _clippingPlanes?: unknown;
+    _clippingPolygons?: unknown;
+  };
+  e._clippingPlanes = undefined;
+  e._clippingPolygons = undefined;
+};
+
 const Cesium3DTileset = createCesiumComponent<CesiumCesium3DTileset, Cesium3DTilesetProps>({
   name: "Cesium3DTileset",
   async create(context, props) {
@@ -183,6 +208,7 @@ const Cesium3DTileset = createCesiumComponent<CesiumCesium3DTileset, Cesium3DTil
       context.primitiveCollection.remove(element);
     }
     if (!element.isDestroyed()) {
+      detachUserOwnedClipping(element);
       element.destroy();
     }
   },

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -117,6 +117,16 @@ const Model = createCesiumComponent<CesiumModel, ModelProps>({
       context.primitiveCollection.remove(element);
     }
     if (!element.isDestroyed()) {
+      // clippingPlanes/clippingPolygons are user-supplied props. The Cesium setters call
+      // ClippingPlane(Polygon)Collection.setOwner, transferring ownership to the Model
+      // (sets _owner = this), so Model.destroy()'s `owner === this` guard passes and would
+      // destroy the user's collection (@cesium/engine Model.js:2834-2854). The public
+      // setters also destroy the previously-owned collection (setOwner: ClippingPlane-
+      // Collection.js:671), so we cannot detach via them. Instead null the private fields
+      // directly so Cesium leaves the user-owned collections intact. resium never creates
+      // these itself, so any present collection came from props.
+      (element as { _clippingPlanes?: unknown })._clippingPlanes = undefined;
+      (element as { _clippingPolygons?: unknown })._clippingPolygons = undefined;
       element.destroy();
     }
   },

--- a/src/PostProcessStageComposite/PostProcessStageComposite.test.ts
+++ b/src/PostProcessStageComposite/PostProcessStageComposite.test.ts
@@ -1,9 +1,15 @@
+import {
+  PostProcessStage,
+  PostProcessStageCollection,
+  PostProcessStageComposite as CesiumPostProcessStageComposite,
+} from "cesium";
 import type { TypeEqual } from "ts-expect";
 import { expectType } from "ts-expect";
-import { it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import type { UnusedCesiumProps } from "../core";
 
+import { removeCompositeWithoutDestroyingChildren } from "./PostProcessStageComposite";
 import type { PostProcessStageCompositeProps, Target } from "./PostProcessStageComposite";
 
 // Unused prop check
@@ -13,3 +19,71 @@ type IgnoredProps = "uniforms"; // uniforms is actually used
 expectType<TypeEqual<never, UnusedProps>>(true);
 
 it("should be compiled", () => {});
+
+const makeStage = (name: string) =>
+  new PostProcessStage({
+    fragmentShader: "void main(){ gl_FragColor = vec4(1.0); }",
+    name,
+  });
+
+describe("removeCompositeWithoutDestroyingChildren", () => {
+  it("does not destroy user-owned child stages on unmount (#602 class)", () => {
+    const a = makeStage("childA");
+    const b = makeStage("childB");
+    const stages = [a, b];
+    const composite = new CesiumPostProcessStageComposite({ stages, name: "comp" });
+    const collection = new PostProcessStageCollection();
+    collection.add(composite);
+
+    removeCompositeWithoutDestroyingChildren(composite, collection as any);
+
+    // The composite resium created is destroyed...
+    expect(composite.isDestroyed()).toBe(true);
+    // ...but the user-owned child stages survive.
+    expect(a.isDestroyed()).toBe(false);
+    expect(b.isDestroyed()).toBe(false);
+    // The user's `stages` array is not mutated.
+    expect(stages).toEqual([a, b]);
+
+    a.destroy();
+    b.destroy();
+  });
+
+  it("frees collection state so the same children can be re-added (StrictMode remount)", () => {
+    const a = makeStage("childA");
+    const b = makeStage("childB");
+    const collection = new PostProcessStageCollection();
+
+    const first = new CesiumPostProcessStageComposite({ stages: [a, b], name: "comp" });
+    collection.add(first);
+    removeCompositeWithoutDestroyingChildren(first, collection as any);
+
+    // The child names must be freed from the collection's `_stageNames` map,
+    // otherwise re-adding the same instances throws "already been added".
+    const stageNames = (collection as any)._stageNames as Record<string, unknown>;
+    expect(stageNames.childA).toBeUndefined();
+    expect(stageNames.childB).toBeUndefined();
+    expect(stageNames.comp).toBeUndefined();
+
+    // Remount: a new composite wrapping the SAME child instances must add cleanly
+    // (Cesium's add throws on duplicate names / already-registered stages).
+    const second = new CesiumPostProcessStageComposite({ stages: [a, b], name: "comp" });
+    expect(() => collection.add(second)).not.toThrow();
+    expect(collection.contains(second)).toBe(true);
+
+    removeCompositeWithoutDestroyingChildren(second, collection as any);
+    a.destroy();
+    b.destroy();
+  });
+
+  it("destroys the composite even when there is no collection", () => {
+    const a = makeStage("childA");
+    const composite = new CesiumPostProcessStageComposite({ stages: [a], name: "comp" });
+
+    removeCompositeWithoutDestroyingChildren(composite, undefined);
+
+    expect(composite.isDestroyed()).toBe(true);
+    expect(a.isDestroyed()).toBe(false);
+    a.destroy();
+  });
+});

--- a/src/PostProcessStageComposite/PostProcessStageComposite.ts
+++ b/src/PostProcessStageComposite/PostProcessStageComposite.ts
@@ -74,6 +74,71 @@ const cesiumProps = ["enabled", "selected"] as const;
 
 const cesiumReadonlyProps = ["inputPreviousStageTexture", "name", "stages", "uniforms"] as const;
 
+type CompositeInternals = { _stages?: unknown[] };
+type StageInternals = { name?: string; _textureCache?: unknown; _index?: unknown };
+type CollectionInternals = {
+  remove(stage: CesiumPostProcessStageComposite): boolean;
+  _stageNames?: Record<string, unknown>;
+};
+
+/**
+ * Removes a resium-owned `PostProcessStageComposite` from the scene's
+ * `PostProcessStageCollection` and destroys it WITHOUT destroying the
+ * user-supplied child `PostProcessStage` instances passed via the `stages` prop.
+ *
+ * resium creates and owns the composite, but it does NOT own the child stages.
+ * Both `PostProcessStageCollection.remove(stage)` and
+ * `PostProcessStageComposite.destroy()` unconditionally destroy every child
+ * stage (Cesium offers no `destroy=false` flag). Under React StrictMode
+ * (mount -> unmount -> remount), the throwaway first unmount would destroy the
+ * user-owned stages, so the real remount reuses already-destroyed stages and
+ * throws "This object was destroyed, i.e., destroy() was called." (same class
+ * of bug as #602).
+ *
+ * The composite stores the user's stages in its internal `_stages` array, which
+ * is the SAME array reference passed in props (`this._stages = options.stages`).
+ * When the collection adds the composite, `add` walks into the children and
+ * registers each one in the collection's `_stageNames` map and stamps
+ * `child._textureCache`. We:
+ *  1. snapshot the children and replace the composite's `_stages` with a fresh
+ *     empty array (NOT emptying the user's array in place) so neither `remove`
+ *     nor `destroy` cascades into the children;
+ *  2. `remove` the (now child-less) composite, which frees the composite's own
+ *     name and slot;
+ *  3. reverse the per-child registration that `add` performed (delete the name
+ *     entry and clear `_textureCache`/`_index`), leaving the user-owned stages
+ *     intact and re-addable on the next mount.
+ *
+ * @internal exported for testing.
+ */
+export const removeCompositeWithoutDestroyingChildren = (
+  element: CesiumPostProcessStageComposite,
+  collection: CollectionInternals | undefined,
+): void => {
+  const internal = element as unknown as CompositeInternals;
+  const children = Array.isArray(internal._stages) ? internal._stages.slice() : [];
+  // Replace (do not mutate) the array: `_stages` aliases the user's `stages`
+  // prop array, so emptying it in place would corrupt the caller's array.
+  internal._stages = [];
+
+  if (collection) {
+    collection.remove(element);
+    const stageNames = collection._stageNames;
+    for (const child of children) {
+      const c = child as StageInternals;
+      if (stageNames && typeof c.name === "string") {
+        Reflect.deleteProperty(stageNames, c.name);
+      }
+      c._textureCache = undefined;
+      c._index = undefined;
+    }
+  }
+
+  if (!element.isDestroyed()) {
+    element.destroy();
+  }
+};
+
 export const PostProcessStageComposite = createCesiumComponent<
   CesiumPostProcessStageComposite,
   PostProcessStageCompositeProps
@@ -92,12 +157,11 @@ export const PostProcessStageComposite = createCesiumComponent<
     return element;
   },
   destroy(element, context) {
-    if (context.scene && !context.scene.isDestroyed()) {
-      context.scene.postProcessStages.remove(element);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
-    }
+    const collection =
+      context.scene && !context.scene.isDestroyed()
+        ? (context.scene.postProcessStages as unknown as CollectionInternals)
+        : undefined;
+    removeCompositeWithoutDestroyingChildren(element, collection);
   },
   cesiumProps,
   cesiumReadonlyProps,

--- a/src/TimeDynamicPointCloud/TimeDynamicPointCloud.test.tsx
+++ b/src/TimeDynamicPointCloud/TimeDynamicPointCloud.test.tsx
@@ -1,0 +1,106 @@
+import { render, waitFor } from "@testing-library/react";
+import type { TimeDynamicPointCloud as CesiumTimeDynamicPointCloud } from "cesium";
+import type { TypeEqual } from "ts-expect";
+import { expectType } from "ts-expect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UnusedCesiumProps } from "../core";
+import { Provider } from "../core";
+
+import type TimeDynamicPointCloudComponent from "./TimeDynamicPointCloud";
+import type {
+  TimeDynamicPointCloudOtherProps,
+  TimeDynamicPointCloudProps,
+} from "./TimeDynamicPointCloud";
+
+// Unused prop check
+type UnusedProps = UnusedCesiumProps<
+  CesiumTimeDynamicPointCloud,
+  Omit<TimeDynamicPointCloudProps, keyof TimeDynamicPointCloudOtherProps>
+>;
+expectType<TypeEqual<never, UnusedProps>>(true);
+
+it("should be compiled", () => {});
+
+// Mimic Cesium's TimeDynamicPointCloud destroy semantics: destroy() unconditionally
+// destroys _clippingPlanes (@cesium/engine/Source/Scene/TimeDynamicPointCloud.js#L798).
+// The fake class is declared inside the factory because vi.mock is hoisted.
+vi.mock("cesium", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("cesium");
+  class FakeTimeDynamicPointCloud {
+    _clippingPlanes: { destroy: () => void } | undefined;
+    destroyed = false;
+    frameChanged = { addEventListener: vi.fn(), removeEventListener: vi.fn() };
+    constructor(options: { clippingPlanes?: { destroy: () => void } }) {
+      this._clippingPlanes = options.clippingPlanes;
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    destroy() {
+      this._clippingPlanes = this._clippingPlanes && (this._clippingPlanes.destroy() as undefined);
+      this.destroyed = true;
+    }
+  }
+  return { ...actual, TimeDynamicPointCloud: FakeTimeDynamicPointCloud };
+});
+
+describe("TimeDynamicPointCloud", () => {
+  let TimeDynamicPointCloud: typeof TimeDynamicPointCloudComponent;
+
+  beforeEach(async () => {
+    console.warn = vi.fn();
+    TimeDynamicPointCloud = (await import("./TimeDynamicPointCloud")).default;
+  });
+
+  const makeContext = () => {
+    const primitiveCollection = {
+      add: vi.fn(),
+      remove: vi.fn(),
+      isDestroyed: () => false,
+    };
+    const cesiumWidget = { clock: {} };
+    return { primitiveCollection, cesiumWidget } as any;
+  };
+
+  it("does not destroy a user-supplied clippingPlanes on unmount", async () => {
+    const destroy = vi.fn();
+    const clippingPlanes = { destroy } as any;
+    const ctx = makeContext();
+
+    const { unmount } = render(
+      <Provider value={ctx}>
+        <TimeDynamicPointCloud clippingPlanes={clippingPlanes} />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(ctx.primitiveCollection.add).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(ctx.primitiveCollection.remove).toHaveBeenCalledTimes(1);
+    });
+    // The user-owned collection must survive unmount.
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  it("destroys the internal clippingPlanes when none was supplied by the user", async () => {
+    const ctx = makeContext();
+
+    const { unmount } = render(
+      <Provider value={ctx}>
+        <TimeDynamicPointCloud />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(ctx.primitiveCollection.add).toHaveBeenCalledTimes(1);
+    });
+
+    // No throw: nothing user-owned to leak.
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/src/TimeDynamicPointCloud/TimeDynamicPointCloud.ts
+++ b/src/TimeDynamicPointCloud/TimeDynamicPointCloud.ts
@@ -95,13 +95,26 @@ const TimeDynamicPointCloud = createCesiumComponent<
       element.frameChanged.addEventListener(handleFrameChanged);
     }
     context.primitiveCollection.add(element);
-    return element;
+    // Remember whether clippingPlanes was user-supplied so that on unmount we can
+    // detach it before destroy() to avoid destroying the user-owned collection.
+    return [element, { userClippingPlanes: !!props.clippingPlanes }];
   },
-  destroy(element, context) {
+  destroy(element, context, _wrapperRef, state) {
     if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
       context.primitiveCollection.remove(element);
     }
     if (!element.isDestroyed()) {
+      // Cesium's TimeDynamicPointCloud.destroy() unconditionally destroys its
+      // clippingPlanes (@cesium/engine/Source/Scene/TimeDynamicPointCloud.js#L798),
+      // and the clippingPlanes setter destroys the previously-owned collection too
+      // (ClippingPlaneCollection.setOwner, ClippingPlaneCollection.js#L671).
+      // When clippingPlanes was supplied by the user, detach it by nulling the
+      // private _clippingPlanes field directly (assigning via the public setter
+      // would also destroy it) so element.destroy() won't destroy the
+      // user-owned collection (same class of issue as #602).
+      if (state?.userClippingPlanes) {
+        (element as unknown as { _clippingPlanes?: unknown })._clippingPlanes = undefined;
+      }
       element.destroy();
     }
   },

--- a/src/Viewer/Viewer.ts
+++ b/src/Viewer/Viewer.ts
@@ -36,8 +36,8 @@ export type ViewerCesiumProps = PickCesiumProps<CesiumViewer, typeof cesiumProps
 export type ViewerCesiumReadonlyProps = PickCesiumProps<Target, typeof cesiumReadonlyProps>;
 
 export type ViewerCesiumEvents = {
-  onSelectedEntityChange?: (entity: Entity) => void;
-  onTrackedEntityChange?: (entity: Entity) => void;
+  onSelectedEntityChange?: (entity: Entity | undefined) => void;
+  onTrackedEntityChange?: (entity: Entity | undefined) => void;
 };
 
 const cesiumProps = [


### PR DESCRIPTION
## Summary
Follow-up to the `Polyline` material fix (#602): an audit of all primitive wrappers found the **same class of bug** in 4 more places — resium destroying a Cesium object that was supplied by the user via props (so the user owns it), breaking reuse under React StrictMode ("This object was destroyed"). Also includes a small Viewer event-type fix.

### Don't-destroy-user-owned-props fixes
- **fix(Cesium3DTileset):** don't destroy user-owned `clippingPlanes`/`clippingPolygons`. `Cesium3DTileset.destroy()` unconditionally destroys them, and the setter transfers ownership via `ClippingPlaneCollection.setOwner`.
- **fix(Model):** same for `clippingPlanes`/`clippingPolygons`. Model's `owner === this` guard is bypassed because the setter moves ownership to the Model.
- **fix(TimeDynamicPointCloud):** same for `clippingPlanes` (unconditional destroy).
- **fix(PostProcessStageComposite):** don't destroy the user-supplied child `PostProcessStage` instances passed via `stages`. Both `composite.destroy()` and `PostProcessStageCollection.remove()` cascade-destroy children; resium owns the composite it created but not the child stages.

Detaching bypasses the public setters (which themselves destroy the previously-owned collection): the fixes null the relevant private references just before `element.destroy()`, only when the prop was user-supplied. ⚠️ This touches Cesium private fields (mirroring documented add/remove bookkeeping) — pragmatic, same spirit as #602, but coupled to Cesium internals. Behavioral tests guard each fix.

### Type fix
- **fix(Viewer):** type `onSelectedEntityChange` / `onTrackedEntityChange` handler arg as `Entity | undefined`. Cesium raises these events with the new entity, which is `undefined` when the selection/track is cleared. Closes **#567**.

## Verification
- `npx tsc --noEmit` ✅ / `npx eslint .` ✅ / `npx vite build` ✅ / `npx vitest run` ✅ (real suite + new tests)

## Related
Audit prompted by the `Polyline` material fix in #780 (#602).