### PR TITLE
fix(docs): wrap Viewer/CesiumWidget @example JSX in code fences (fix Build docs)

### DIFF
--- a/src/CesiumWidget/CesiumWidget.ts
+++ b/src/CesiumWidget/CesiumWidget.ts
@@ -22,7 +22,9 @@ import {
 
 /*
 @example
+```jsx
 <CesiumWidget full />
+```
 */
 
 /*

--- a/src/Viewer/Viewer.ts
+++ b/src/Viewer/Viewer.ts
@@ -21,7 +21,9 @@ import {
 
 /*
 @example
+```jsx
 <Viewer full animation={false} timeline={false} />
+```
 */
 
 /*


### PR DESCRIPTION
Main's `ci` workflow **Build docs** job is failing after #779 started rendering `@example` sections.

`Viewer` and `CesiumWidget` have pre-existing `@example` comments containing **bare JSX** (`<Viewer ... />`, `<CesiumWidget full />`). Now that those sections are rendered, Docusaurus tries to resolve `<Viewer>`/`<CesiumWidget>` as MDX components and the production SSG fails:

> Expected component `Viewer` to be defined: you likely forgot to import, pass, or provide it.

Fix: wrap the JSX in ```jsx code fences so MDX treats them as code, not components.

Verified locally: `yarn docs:generate` + `docusaurus build` now completes with no warnings/errors.