### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,25 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: resium
+  namespace: reearth
+  description: React components for 🌏 Cesium
+  annotations:
+    github.com/project-slug: reearth/resium
+  links:
+  - url: https://github.com/reearth/resium
+    title: GitHub
+    icon: github
+  - url: https://resium.reearth.io
+    title: Website
+    icon: web
+  tags:
+  - typescript
+  - react
+  - cesium
+  - javascript
+  - map
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/lib


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `resium` (namespace `reearth`)
- **Owner:** `reearth/lib`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.