### PR TITLE
feat: support Cesium 1.142 — vector tiles, GeoJSON primitives, edge mode, blend option, multi-key modifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test
         run: yarn run test
       - name: Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       - name: Build
         run: yarn run build
       - name: Upload artifacts

--- a/docs/src/content/docs/migration.md
+++ b/docs/src/content/docs/migration.md
@@ -2,6 +2,27 @@
 title: Migration Guide
 ---
 
+## v1.23
+
+### `BufferPointCollection` / `BufferPolylineCollection` / `BufferPolygonCollection` — `boundingVolume` is interpreted in world space
+
+Cesium 1.142 changed the semantic of `boundingVolume` on these three collections from local/model space to **world space**. Resium now exposes `boundingVolume` as a constructor prop, so this affects any consumer who passes a precomputed bounding volume:
+
+```jsx
+// Before (Cesium <=1.141, when reaching the underlying primitive via ref):
+// boundingVolume was implicitly local-space, transformed by `modelMatrix`.
+
+// Now (Cesium 1.142+, via Resium's new prop):
+<BufferPointCollection
+  primitiveCountMax={positions.length}
+  modelMatrix={modelMatrix}
+  // Apply the same modelMatrix to the bounding volume that you apply to the points.
+  boundingVolume={worldSpaceBoundingSphere}
+/>
+```
+
+If you do not pass `boundingVolume`, Cesium computes it for you each frame — unchanged behavior. Upstream change: [CesiumGS/cesium#13477](https://github.com/CesiumGS/cesium/pull/13477).
+
 ## v1.14
 
 ### Event handlers no longer receive an entity and primitive directly

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "storybook": "storybook dev -p 9001",
     "storybook:build": "storybook build -o docs/public/examples",
     "storybook:build:vrt": "storybook build -o storybook-static",
-    "vrt:test": "test-storybook --url http://127.0.0.1:6006 --includeTags vrt",
+    "vrt:test": "test-storybook --url http://127.0.0.1:6006 --includeTags vrt --testTimeout=30000",
     "vrt:capture": "concurrently -k -s first \"http-server storybook-static -p 6006 -s --silent\" \"wait-on tcp:127.0.0.1:6006 && yarn vrt:test\"",
     "vrt:run": "reg-suit run",
     "vrt": "run-s vrt:capture vrt:run",

--- a/package.json
+++ b/package.json
@@ -68,14 +68,14 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "c8": "11.0.0",
-    "cesium": "1.141.0",
-    "concurrently": "^10.0.0",
-    "eslint": "10.4.0",
+    "cesium": "1.142.0",
+    "concurrently": "^10.0.1",
+    "eslint": "10.4.1",
     "eslint-config-reearth": "0.4.0",
     "globby": "16.2.0",
     "http-server": "^14.1.1",
     "jsdom": "29.1.1",
-    "npm-run-all2": "9.0.0",
+    "npm-run-all2": "9.0.1",
     "prettier": "^3.8.3",
     "react": "19.2.6",
     "react-dom": "19.2.6",
@@ -92,6 +92,6 @@
     "vite-plugin-dts": "5.0.1",
     "vitest": "4.1.7",
     "wait-on": "^9.0.10",
-    "web-streams-polyfill": "^4.2.0"
+    "web-streams-polyfill": "^4.3.0"
   }
 }

--- a/src/BufferPointCollection/BufferPointCollection.stories.tsx
+++ b/src/BufferPointCollection/BufferPointCollection.stories.tsx
@@ -1,0 +1,64 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { BlendOption, BufferPointMaterial, Cartesian3, Color } from "cesium";
+
+import BufferPoint from "../BufferPoint";
+import CameraFlyTo from "../CameraFlyTo";
+import Viewer from "../Viewer";
+
+import BufferPointCollection from "./BufferPointCollection";
+
+type Story = StoryObj<typeof BufferPointCollection>;
+
+export default {
+  title: "BufferPointCollection",
+  component: BufferPointCollection,
+} as Meta;
+
+const positions = Array.from({ length: 50 }, (_, i) => {
+  const angle = (i / 50) * 2 * Math.PI;
+  return Cartesian3.fromDegrees(-95.0 + 0.3 * Math.cos(angle), 40.0 + 0.3 * Math.sin(angle));
+});
+
+const opaqueMaterial = new BufferPointMaterial({ color: Color.CYAN, size: 12 });
+
+export const Opaque: Story = {
+  render: () => (
+    <Viewer full>
+      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 250_000)} duration={0} />
+      <BufferPointCollection primitiveCountMax={positions.length}>
+        {positions.map((position, i) => (
+          <BufferPoint key={i} position={position} material={opaqueMaterial} />
+        ))}
+      </BufferPointCollection>
+    </Viewer>
+  ),
+};
+
+/**
+ * Translucent variant — demonstrates the new `blendOption` ctor prop (Cesium 1.142+).
+ * `blendOption` alone is invisible without an alpha-aware material; the
+ * `BufferPointMaterial` here sets `color.alpha < 1` and `outlineColor.alpha < 1`
+ * to actually produce translucent points.
+ */
+export const Translucent: Story = {
+  render: () => {
+    const translucentMaterial = new BufferPointMaterial({
+      color: Color.RED.withAlpha(0.35),
+      outlineColor: Color.YELLOW.withAlpha(0.6),
+      outlineWidth: 2,
+      size: 16,
+    });
+    return (
+      <Viewer full>
+        <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 250_000)} duration={0} />
+        <BufferPointCollection
+          primitiveCountMax={positions.length}
+          blendOption={BlendOption.OPAQUE_AND_TRANSLUCENT}>
+          {positions.map((position, i) => (
+            <BufferPoint key={i} position={position} material={translucentMaterial} />
+          ))}
+        </BufferPointCollection>
+      </Viewer>
+    );
+  },
+};

--- a/src/BufferPointCollection/BufferPointCollection.test.ts
+++ b/src/BufferPointCollection/BufferPointCollection.test.ts
@@ -15,12 +15,16 @@ type UnusedProps = UnusedCesiumProps<
   BufferPointCollection,
   Omit<
     BufferPointCollectionProps,
-    keyof BufferPointCollectionOtherProps | "primitiveCountMax" | "modelMatrix"
+    | keyof BufferPointCollectionOtherProps
+    | "primitiveCountMax"
+    | "modelMatrix"
+    | "boundingVolume"
+    | "blendOption"
   >,
   {},
   IgnoredProps
 >;
-type IgnoredProps = "length" | "DEFAULT_CAPACITY" | "boundingVolume" | "boundingVolumeWC";
+type IgnoredProps = "length" | "DEFAULT_CAPACITY" | "boundingVolumeWC";
 
 expectType<TypeEqual<never, UnusedProps>>(true);
 

--- a/src/BufferPointCollection/BufferPointCollection.ts
+++ b/src/BufferPointCollection/BufferPointCollection.ts
@@ -1,5 +1,4 @@
-import type {
-  Matrix4} from "cesium";
+import type { BlendOption, BoundingSphere, Matrix4 } from "cesium";
 import {
   BufferPointCollection as CesiumBufferPointCollection
 } from "cesium";
@@ -37,6 +36,20 @@ export type BufferPointCollectionConstructorProps = {
    * a ref and mutate the Matrix4 in place via `Matrix4.clone(next, current)`.
    */
   modelMatrix?: Matrix4;
+  /**
+   * Precomputed bounding volume. **Interpreted in world space** (Cesium 1.142+);
+   * apply the same `modelMatrix` to the bounding volume that you apply to the
+   * points. Providing this skips the per-frame recompute cost on large animated
+   * collections. Fixed at creation time.
+   */
+  boundingVolume?: BoundingSphere;
+  /**
+   * Blending mode for the collection. Use `BlendOption.OPAQUE_AND_TRANSLUCENT`
+   * (or `TRANSLUCENT`) together with a `BufferPrimitiveMaterial` whose
+   * `color.alpha`/`outlineColor.alpha` is less than 1 to render translucent
+   * points. Fixed at creation time.
+   */
+  blendOption?: BlendOption;
 };
 
 // Cesium 1.141's BufferPointCollection subclass constructor type omits the
@@ -45,7 +58,7 @@ export type BufferPointCollectionConstructorProps = {
 // the prop without losing typechecking on the rest of the options.
 type BufferPointCollectionCtorOptions = ConstructorParameters<
   typeof CesiumBufferPointCollection
->[0] & { modelMatrix?: Matrix4 };
+>[0] & { modelMatrix?: Matrix4; boundingVolume?: BoundingSphere; blendOption?: BlendOption };
 
 export type BufferPointCollectionOtherProps = {
   children?: ReactNode;
@@ -57,7 +70,12 @@ export type BufferPointCollectionProps = BufferPointCollectionCesiumProps &
 
 const cesiumProps = ["show", "debugShowBoundingVolume"] as const;
 
-const cesiumReadonlyProps = ["primitiveCountMax", "modelMatrix"] as const;
+const cesiumReadonlyProps = [
+  "primitiveCountMax",
+  "modelMatrix",
+  "boundingVolume",
+  "blendOption",
+] as const;
 
 const BufferPointCollection = createCesiumComponent<
   CesiumBufferPointCollection,
@@ -69,6 +87,8 @@ const BufferPointCollection = createCesiumComponent<
     const element = new CesiumBufferPointCollection({
       primitiveCountMax: props.primitiveCountMax,
       modelMatrix: props.modelMatrix,
+      boundingVolume: props.boundingVolume,
+      blendOption: props.blendOption,
     } as BufferPointCollectionCtorOptions);
     context.primitiveCollection.add(element);
     return element;

--- a/src/BufferPolygonCollection/BufferPolygonCollection.stories.tsx
+++ b/src/BufferPolygonCollection/BufferPolygonCollection.stories.tsx
@@ -1,0 +1,73 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { BlendOption, BufferPolygonMaterial, Cartesian3, Color } from "cesium";
+
+import BufferPolygon from "../BufferPolygon";
+import CameraFlyTo from "../CameraFlyTo";
+import Viewer from "../Viewer";
+
+import BufferPolygonCollection from "./BufferPolygonCollection";
+
+type Story = StoryObj<typeof BufferPolygonCollection>;
+
+export default {
+  title: "BufferPolygonCollection",
+  component: BufferPolygonCollection,
+} as Meta;
+
+// Pack three world-space positions into a flat Float64Array (x, y, z per vertex)
+// and provide a triangle index buffer — BufferPolygon needs both to render.
+const p1 = Cartesian3.fromDegrees(-95.4, 39.8, 0);
+const p2 = Cartesian3.fromDegrees(-94.6, 39.8, 0);
+const p3 = Cartesian3.fromDegrees(-95.0, 40.2, 0);
+const positions = new Float64Array([p1.x, p1.y, p1.z, p2.x, p2.y, p2.z, p3.x, p3.y, p3.z]);
+const triangles = new Uint32Array([0, 1, 2]);
+const vertexCount = positions.length / 3;
+const triangleCount = triangles.length;
+
+export const Opaque: Story = {
+  render: () => (
+    <Viewer full>
+      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 250_000)} duration={0} />
+      <BufferPolygonCollection
+        primitiveCountMax={1}
+        vertexCountMax={vertexCount}
+        triangleCountMax={triangleCount}>
+        <BufferPolygon
+          positions={positions}
+          triangles={triangles}
+          material={new BufferPolygonMaterial({ color: Color.CYAN })}
+        />
+      </BufferPolygonCollection>
+    </Viewer>
+  ),
+};
+
+/**
+ * Translucent variant — demonstrates the new `blendOption` ctor prop (Cesium 1.142+).
+ * `blendOption` alone is invisible without an alpha-aware material; the
+ * `BufferPolygonMaterial` here sets `color.alpha < 1` to actually produce
+ * a translucent polygon.
+ */
+export const Translucent: Story = {
+  render: () => {
+    const translucentMaterial = new BufferPolygonMaterial({
+      color: Color.BLUE.withAlpha(0.3),
+    });
+    return (
+      <Viewer full>
+        <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 250_000)} duration={0} />
+        <BufferPolygonCollection
+          primitiveCountMax={1}
+          vertexCountMax={vertexCount}
+          triangleCountMax={triangleCount}
+          blendOption={BlendOption.OPAQUE_AND_TRANSLUCENT}>
+          <BufferPolygon
+            positions={positions}
+            triangles={triangles}
+            material={translucentMaterial}
+          />
+        </BufferPolygonCollection>
+      </Viewer>
+    );
+  },
+};

--- a/src/BufferPolygonCollection/BufferPolygonCollection.test.ts
+++ b/src/BufferPolygonCollection/BufferPolygonCollection.test.ts
@@ -7,16 +7,26 @@ import type { UnusedCesiumProps } from "../core";
 
 import type { BufferPolygonCollectionOtherProps, BufferPolygonCollectionProps } from "./BufferPolygonCollection";
 
-type ConstructorOnlyProps = "primitiveCountMax" | "vertexCountMax" | "holeCountMax" | "triangleCountMax" | "positionDatatype" | "allowPicking" | "modelMatrix";
-
 // Unused prop check
 type UnusedProps = UnusedCesiumProps<
   BufferPolygonCollection,
-  Omit<BufferPolygonCollectionProps, keyof BufferPolygonCollectionOtherProps | ConstructorOnlyProps>,
+  Omit<
+    BufferPolygonCollectionProps,
+    | keyof BufferPolygonCollectionOtherProps
+    | "primitiveCountMax"
+    | "vertexCountMax"
+    | "holeCountMax"
+    | "triangleCountMax"
+    | "positionDatatype"
+    | "allowPicking"
+    | "modelMatrix"
+    | "boundingVolume"
+    | "blendOption"
+  >,
   {},
   IgnoredProps
 >;
-type IgnoredProps = "length" | "DEFAULT_CAPACITY" | "boundingVolume" | "boundingVolumeWC";
+type IgnoredProps = "length" | "DEFAULT_CAPACITY" | "boundingVolumeWC";
 
 expectType<TypeEqual<never, UnusedProps>>(true);
 

--- a/src/BufferPolygonCollection/BufferPolygonCollection.ts
+++ b/src/BufferPolygonCollection/BufferPolygonCollection.ts
@@ -1,6 +1,4 @@
-import type {
-  ComponentDatatype,
-  Matrix4} from "cesium";
+import type { BlendOption, BoundingSphere, ComponentDatatype, Matrix4 } from "cesium";
 import {
   BufferPolygonCollection as CesiumBufferPolygonCollection
 } from "cesium";
@@ -48,6 +46,18 @@ export type BufferPolygonCollectionConstructorProps = {
    * a ref and mutate the Matrix4 in place via `Matrix4.clone(next, current)`.
    */
   modelMatrix?: Matrix4;
+  /**
+   * Precomputed bounding volume. **Interpreted in world space** (Cesium 1.142+);
+   * apply the same `modelMatrix` to the bounding volume that you apply to the
+   * polygons. Fixed at creation time.
+   */
+  boundingVolume?: BoundingSphere;
+  /**
+   * Blending mode for the collection. Pair with an alpha-aware
+   * `BufferPrimitiveMaterial` to render translucent polygons. Fixed at
+   * creation time.
+   */
+  blendOption?: BlendOption;
 };
 
 // Cesium 1.141's BufferPolygonCollection subclass constructor type omits the
@@ -56,7 +66,11 @@ export type BufferPolygonCollectionConstructorProps = {
 // the prop without losing typechecking on the rest of the options.
 type BufferPolygonCollectionCtorOptions = ConstructorParameters<
   typeof CesiumBufferPolygonCollection
->[0] & { modelMatrix?: Matrix4 };
+>[0] & {
+  modelMatrix?: Matrix4;
+  boundingVolume?: BoundingSphere;
+  blendOption?: BlendOption;
+};
 
 export type BufferPolygonCollectionOtherProps = {
   children?: ReactNode;
@@ -76,6 +90,8 @@ const cesiumReadonlyProps = [
   "positionDatatype",
   "allowPicking",
   "modelMatrix",
+  "boundingVolume",
+  "blendOption",
 ] as const;
 
 const BufferPolygonCollection = createCesiumComponent<
@@ -93,6 +109,8 @@ const BufferPolygonCollection = createCesiumComponent<
       positionDatatype: props.positionDatatype,
       allowPicking: props.allowPicking,
       modelMatrix: props.modelMatrix,
+      boundingVolume: props.boundingVolume,
+      blendOption: props.blendOption,
     } as BufferPolygonCollectionCtorOptions);
     context.primitiveCollection.add(element);
     return element;

--- a/src/BufferPolylineCollection/BufferPolylineCollection.stories.tsx
+++ b/src/BufferPolylineCollection/BufferPolylineCollection.stories.tsx
@@ -1,0 +1,67 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { BlendOption, BufferPolylineMaterial, Cartesian3, Color } from "cesium";
+
+import BufferPolyline from "../BufferPolyline";
+import CameraFlyTo from "../CameraFlyTo";
+import Viewer from "../Viewer";
+
+import BufferPolylineCollection from "./BufferPolylineCollection";
+
+type Story = StoryObj<typeof BufferPolylineCollection>;
+
+export default {
+  title: "BufferPolylineCollection",
+  component: BufferPolylineCollection,
+} as Meta;
+
+// Pack four world-space positions into a flat Float64Array (x, y, z per vertex).
+const p1 = Cartesian3.fromDegrees(-95.4, 39.8);
+const p2 = Cartesian3.fromDegrees(-94.6, 40.2);
+const p3 = Cartesian3.fromDegrees(-94.6, 39.8);
+const p4 = Cartesian3.fromDegrees(-95.4, 40.2);
+const positions = new Float64Array([
+  p1.x, p1.y, p1.z,
+  p2.x, p2.y, p2.z,
+  p3.x, p3.y, p3.z,
+  p4.x, p4.y, p4.z,
+]);
+const vertexCount = positions.length / 3;
+
+const opaqueMaterial = new BufferPolylineMaterial({ color: Color.CYAN, width: 5 });
+
+export const Opaque: Story = {
+  render: () => (
+    <Viewer full>
+      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 250_000)} duration={0} />
+      <BufferPolylineCollection primitiveCountMax={1} vertexCountMax={vertexCount}>
+        <BufferPolyline positions={positions} material={opaqueMaterial} />
+      </BufferPolylineCollection>
+    </Viewer>
+  ),
+};
+
+/**
+ * Translucent variant — demonstrates the new `blendOption` ctor prop (Cesium 1.142+).
+ * `blendOption` alone is invisible without an alpha-aware material; the
+ * `BufferPolylineMaterial` here sets `color.alpha < 1` to actually produce
+ * a translucent polyline.
+ */
+export const Translucent: Story = {
+  render: () => {
+    const translucentMaterial = new BufferPolylineMaterial({
+      color: Color.RED.withAlpha(0.4),
+      width: 6,
+    });
+    return (
+      <Viewer full>
+        <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 250_000)} duration={0} />
+        <BufferPolylineCollection
+          primitiveCountMax={1}
+          vertexCountMax={vertexCount}
+          blendOption={BlendOption.OPAQUE_AND_TRANSLUCENT}>
+          <BufferPolyline positions={positions} material={translucentMaterial} />
+        </BufferPolylineCollection>
+      </Viewer>
+    );
+  },
+};

--- a/src/BufferPolylineCollection/BufferPolylineCollection.test.ts
+++ b/src/BufferPolylineCollection/BufferPolylineCollection.test.ts
@@ -12,12 +12,17 @@ type UnusedProps = UnusedCesiumProps<
   BufferPolylineCollection,
   Omit<
     BufferPolylineCollectionProps,
-    keyof BufferPolylineCollectionOtherProps | "primitiveCountMax" | "vertexCountMax" | "modelMatrix"
+    | keyof BufferPolylineCollectionOtherProps
+    | "primitiveCountMax"
+    | "vertexCountMax"
+    | "modelMatrix"
+    | "boundingVolume"
+    | "blendOption"
   >,
   {},
   IgnoredProps
 >;
-type IgnoredProps = "length" | "DEFAULT_CAPACITY" | "boundingVolume" | "boundingVolumeWC";
+type IgnoredProps = "length" | "DEFAULT_CAPACITY" | "boundingVolumeWC";
 
 expectType<TypeEqual<never, UnusedProps>>(true);
 

--- a/src/BufferPolylineCollection/BufferPolylineCollection.ts
+++ b/src/BufferPolylineCollection/BufferPolylineCollection.ts
@@ -1,5 +1,4 @@
-import type {
-  Matrix4} from "cesium";
+import type { BlendOption, BoundingSphere, Matrix4 } from "cesium";
 import {
   BufferPolylineCollection as CesiumBufferPolylineCollection
 } from "cesium";
@@ -39,6 +38,18 @@ export type BufferPolylineCollectionConstructorProps = {
    * a ref and mutate the Matrix4 in place via `Matrix4.clone(next, current)`.
    */
   modelMatrix?: Matrix4;
+  /**
+   * Precomputed bounding volume. **Interpreted in world space** (Cesium 1.142+);
+   * apply the same `modelMatrix` to the bounding volume that you apply to the
+   * polylines. Fixed at creation time.
+   */
+  boundingVolume?: BoundingSphere;
+  /**
+   * Blending mode for the collection. Pair with an alpha-aware
+   * `BufferPrimitiveMaterial` to render translucent polylines. Fixed at
+   * creation time.
+   */
+  blendOption?: BlendOption;
 };
 
 export type BufferPolylineCollectionOtherProps = {
@@ -51,7 +62,13 @@ export type BufferPolylineCollectionProps = BufferPolylineCollectionCesiumProps 
 
 const cesiumProps = ["show", "debugShowBoundingVolume"] as const;
 
-const cesiumReadonlyProps = ["primitiveCountMax", "vertexCountMax", "modelMatrix"] as const;
+const cesiumReadonlyProps = [
+  "primitiveCountMax",
+  "vertexCountMax",
+  "modelMatrix",
+  "boundingVolume",
+  "blendOption",
+] as const;
 
 const BufferPolylineCollection = createCesiumComponent<
   CesiumBufferPolylineCollection,
@@ -64,6 +81,8 @@ const BufferPolylineCollection = createCesiumComponent<
       primitiveCountMax: props.primitiveCountMax,
       vertexCountMax: props.vertexCountMax,
       modelMatrix: props.modelMatrix,
+      boundingVolume: props.boundingVolume,
+      blendOption: props.blendOption,
     });
     context.primitiveCollection.add(element);
     return element;

--- a/src/Cesium3DTileset/Cesium3DTileset.stories.tsx
+++ b/src/Cesium3DTileset/Cesium3DTileset.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react";
-import { Viewer as CesiumViewer, Cesium3DTileStyle, IonResource } from "cesium";
+import { Viewer as CesiumViewer, Cesium3DTileStyle, IonResource, EdgeDisplayMode } from "cesium";
 import { useMemo, useRef } from "react";
 
 import { CesiumComponentRef } from "../core";
@@ -70,6 +70,32 @@ export const Style: Story = {
               },
             })
           }
+          onReady={tileset => {
+            ref.current?.cesiumElement?.zoomTo(tileset);
+          }}
+        />
+      </Viewer>
+    );
+  },
+};
+
+/**
+ * Demonstrates the new `edgeDisplayMode` prop (Cesium 1.142+). Visible effect
+ * requires source tilesets containing the `EXT_mesh_primitive_edge_visibility`
+ * glTF extension. Most demo tilesets do not include edge data, so this story
+ * documents the prop wiring; swap `url` for an edge-equipped tileset locally
+ * to see CAD-style wireframe rendering.
+ */
+export const EdgeDisplay: Story = {
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const ref = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    return (
+      <Viewer full ref={ref}>
+        <Cesium3DTileset
+          {...args}
+          url="./tileset/tileset.json"
+          edgeDisplayMode={EdgeDisplayMode.SURFACES_AND_EDGES}
           onReady={tileset => {
             ref.current?.cesiumElement?.zoomTo(tileset);
           }}

--- a/src/Cesium3DTileset/Cesium3DTileset.ts
+++ b/src/Cesium3DTileset/Cesium3DTileset.ts
@@ -108,6 +108,7 @@ const cesiumProps = [
   "dynamicScreenSpaceErrorDensity",
   "dynamicScreenSpaceErrorFactor",
   "dynamicScreenSpaceErrorHeightFalloff",
+  "edgeDisplayMode",
   "skipLevelOfDetail",
   "baseScreenSpaceError",
   "skipScreenSpaceErrorFactor",

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
@@ -8,6 +8,7 @@ import {
   Cartesian3,
   Color,
 } from "cesium";
+import { useMemo } from "react";
 
 import CameraFlyTo from "../CameraFlyTo";
 import Viewer from "../Viewer";
@@ -114,34 +115,53 @@ export const Inline: Story = {
 };
 
 /**
- * Loads Cesium's `simplestyles.geojson` sample — a FeatureCollection of 154
- * Point features arranged in a small grid near (0°, 0°). Applies a visible
- * point material in `onReady` so the grid actually renders.
+ * Loads a GeoJSON FeatureCollection from a **blob URL** generated at story-init
+ * time and renders it over the central United States. The blob carries an
+ * 11x11 grid of Point features centered on (-95°, 40°) at 0.2° spacing — same
+ * URL-fetching codepath as a real HTTPS endpoint, but self-contained so no
+ * external service can break this story.
  *
- * (The Cesium sample dataset URL used to point at `sampleGeoJson.json`, which
- * 404s in the current CesiumGS/cesium repo. `simplestyles.geojson` is the
- * still-present alternative.)
+ * The blob URL is memoized so re-renders don't refetch / rebuild the primitive.
  */
 export const FromUrl: Story = {
-  render: args => (
-    <Viewer full>
-      <CameraFlyTo destination={Cartesian3.fromDegrees(0.7, -0.5, 500_000)} duration={0} />
-      <GeoJsonPrimitive
-        {...args}
-        url="https://raw.githubusercontent.com/CesiumGS/cesium/main/Apps/SampleData/simplestyles.geojson"
-        onReady={primitive => {
-          action("onReady")(primitive);
-          applyVisibleStyle(primitive, {
-            pointMaterial: new BufferPointMaterial({
-              size: 16,
-              color: Color.CYAN,
-              outlineColor: Color.WHITE,
-              outlineWidth: 2,
-            }),
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const url = useMemo(() => {
+      const features = [];
+      for (let lon = -96; lon <= -94; lon += 0.2) {
+        for (let lat = 39; lat <= 41; lat += 0.2) {
+          features.push({
+            type: "Feature" as const,
+            geometry: { type: "Point" as const, coordinates: [lon, lat] },
+            properties: {},
           });
-        }}
-        onError={action("onError")}
-      />
-    </Viewer>
-  ),
+        }
+      }
+      const fc = { type: "FeatureCollection" as const, features };
+      return URL.createObjectURL(
+        new Blob([JSON.stringify(fc)], { type: "application/json" }),
+      );
+    }, []);
+    return (
+      <Viewer full>
+        <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 600_000)} duration={0} />
+        <GeoJsonPrimitive
+          {...args}
+          url={url}
+          onReady={primitive => {
+            action("onReady")(primitive);
+            applyVisibleStyle(primitive, {
+              pointMaterial: new BufferPointMaterial({
+                size: 14,
+                color: Color.CYAN,
+                outlineColor: Color.WHITE,
+                outlineWidth: 2,
+              }),
+            });
+          }}
+          onError={action("onError")}
+        />
+      </Viewer>
+    );
+  },
 };

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
@@ -1,10 +1,17 @@
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react";
-import { Cartesian3 } from "cesium";
+import {
+  BufferPointMaterial,
+  BufferPolygonMaterial,
+  BufferPolylineMaterial,
+  Cartesian3,
+  Color,
+} from "cesium";
 
 import CameraFlyTo from "../CameraFlyTo";
 import Viewer from "../Viewer";
 
+import type { GeoJsonPrimitiveShape } from "./GeoJsonPrimitive";
 import GeoJsonPrimitive from "./GeoJsonPrimitive";
 
 type Story = StoryObj<typeof GeoJsonPrimitive>;
@@ -36,6 +43,47 @@ const inlineGeoJson = {
   ],
 };
 
+/**
+ * `GeoJsonPrimitive` populates its internal `BufferPoint/Polyline/PolygonCollection`s
+ * from the GeoJSON features but does NOT apply default visible styling — points default
+ * to ~0px and polygons render with no fill. This helper walks each collection and
+ * assigns a visible material per feature. Apply it inside `onReady`.
+ */
+function applyVisibleStyle(
+  primitive: GeoJsonPrimitiveShape,
+  opts: {
+    pointMaterial?: BufferPointMaterial;
+    polylineMaterial?: BufferPolylineMaterial;
+    polygonMaterial?: BufferPolygonMaterial;
+  },
+): void {
+  const { pointMaterial, polylineMaterial, polygonMaterial } = opts;
+  const points = primitive.points;
+  if (points && pointMaterial) {
+    for (let i = 0; i < points.length; i++) {
+      points.get(i).material = pointMaterial;
+    }
+  }
+  const polylines = primitive.polylines;
+  if (polylines && polylineMaterial) {
+    for (let i = 0; i < polylines.length; i++) {
+      polylines.get(i).material = polylineMaterial;
+    }
+  }
+  const polygons = primitive.polygons;
+  if (polygons && polygonMaterial) {
+    for (let i = 0; i < polygons.length; i++) {
+      polygons.get(i).material = polygonMaterial;
+    }
+  }
+}
+
+/**
+ * Loads an inline FeatureCollection (one Point + one LineString) and applies
+ * visible materials in `onReady`. Without the post-mount styling, the point
+ * would render at default ~0px size and be invisible — `GeoJsonPrimitive`'s
+ * Buffer collections do not ship with visible defaults.
+ */
 export const Inline: Story = {
   render: args => (
     <Viewer full>
@@ -43,13 +91,33 @@ export const Inline: Story = {
       <GeoJsonPrimitive
         {...args}
         data={inlineGeoJson}
-        onReady={action("onReady")}
+        onReady={primitive => {
+          action("onReady")(primitive);
+          applyVisibleStyle(primitive, {
+            pointMaterial: new BufferPointMaterial({
+              size: 18,
+              color: Color.RED,
+              outlineColor: Color.WHITE,
+              outlineWidth: 2,
+            }),
+            polylineMaterial: new BufferPolylineMaterial({
+              width: 4,
+              color: Color.YELLOW,
+            }),
+          });
+        }}
         onError={action("onError")}
       />
     </Viewer>
   ),
 };
 
+/**
+ * Loads Cesium's sample GeoJSON (a FeatureCollection of US state polygons) and
+ * applies a visible polygon fill in `onReady`. Without the post-mount styling,
+ * the polygons would decode and load correctly but render with no fill — you'd
+ * see an empty globe.
+ */
 export const FromUrl: Story = {
   render: args => (
     <Viewer full>
@@ -57,7 +125,16 @@ export const FromUrl: Story = {
       <GeoJsonPrimitive
         {...args}
         url="https://raw.githubusercontent.com/CesiumGS/cesium/main/Apps/SampleData/sampleGeoJson.json"
-        onReady={action("onReady")}
+        onReady={primitive => {
+          action("onReady")(primitive);
+          applyVisibleStyle(primitive, {
+            polygonMaterial: new BufferPolygonMaterial({
+              color: Color.fromBytes(51, 136, 255, 153), // translucent blue
+              outlineColor: Color.WHITE,
+              outlineWidth: 1,
+            }),
+          });
+        }}
         onError={action("onError")}
       />
     </Viewer>

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
@@ -114,25 +114,29 @@ export const Inline: Story = {
 };
 
 /**
- * Loads Cesium's sample GeoJSON (a FeatureCollection of US state polygons) and
- * applies a visible polygon fill in `onReady`. Without the post-mount styling,
- * the polygons would decode and load correctly but render with no fill — you'd
- * see an empty globe.
+ * Loads Cesium's `simplestyles.geojson` sample — a FeatureCollection of 154
+ * Point features arranged in a small grid near (0°, 0°). Applies a visible
+ * point material in `onReady` so the grid actually renders.
+ *
+ * (The Cesium sample dataset URL used to point at `sampleGeoJson.json`, which
+ * 404s in the current CesiumGS/cesium repo. `simplestyles.geojson` is the
+ * still-present alternative.)
  */
 export const FromUrl: Story = {
   render: args => (
     <Viewer full>
-      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 5_000_000)} duration={0} />
+      <CameraFlyTo destination={Cartesian3.fromDegrees(0.7, -0.5, 500_000)} duration={0} />
       <GeoJsonPrimitive
         {...args}
-        url="https://raw.githubusercontent.com/CesiumGS/cesium/main/Apps/SampleData/sampleGeoJson.json"
+        url="https://raw.githubusercontent.com/CesiumGS/cesium/main/Apps/SampleData/simplestyles.geojson"
         onReady={primitive => {
           action("onReady")(primitive);
           applyVisibleStyle(primitive, {
-            polygonMaterial: new BufferPolygonMaterial({
-              color: Color.fromBytes(51, 136, 255, 153), // translucent blue
+            pointMaterial: new BufferPointMaterial({
+              size: 16,
+              color: Color.CYAN,
               outlineColor: Color.WHITE,
-              outlineWidth: 1,
+              outlineWidth: 2,
             }),
           });
         }}

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
@@ -1,0 +1,65 @@
+import { action } from "storybook/actions";
+import { Meta, StoryObj } from "@storybook/react";
+import { Cartesian3 } from "cesium";
+
+import CameraFlyTo from "../CameraFlyTo";
+import Viewer from "../Viewer";
+
+import GeoJsonPrimitive from "./GeoJsonPrimitive";
+
+type Story = StoryObj<typeof GeoJsonPrimitive>;
+
+export default {
+  title: "GeoJsonPrimitive",
+  component: GeoJsonPrimitive,
+} as Meta;
+
+const inlineGeoJson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [-95.0, 40.0] },
+      properties: { id: "p1" },
+    },
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-96.0, 39.5],
+          [-94.0, 40.5],
+        ],
+      },
+      properties: { id: "l1" },
+    },
+  ],
+};
+
+export const Inline: Story = {
+  render: args => (
+    <Viewer full>
+      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 1_000_000)} duration={0} />
+      <GeoJsonPrimitive
+        {...args}
+        data={inlineGeoJson}
+        onReady={action("onReady")}
+        onError={action("onError")}
+      />
+    </Viewer>
+  ),
+};
+
+export const FromUrl: Story = {
+  render: args => (
+    <Viewer full>
+      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 5_000_000)} duration={0} />
+      <GeoJsonPrimitive
+        {...args}
+        url="https://raw.githubusercontent.com/CesiumGS/cesium/main/Apps/SampleData/sampleGeoJson.json"
+        onReady={action("onReady")}
+        onError={action("onError")}
+      />
+    </Viewer>
+  ),
+};

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.stories.tsx
@@ -4,6 +4,7 @@ import {
   BufferPointMaterial,
   BufferPolygonMaterial,
   BufferPolylineMaterial,
+  BufferPrimitive,
   Cartesian3,
   Color,
 } from "cesium";
@@ -58,22 +59,22 @@ function applyVisibleStyle(
   },
 ): void {
   const { pointMaterial, polylineMaterial, polygonMaterial } = opts;
-  const points = primitive.points;
-  if (points && pointMaterial) {
-    for (let i = 0; i < points.length; i++) {
-      points.get(i).material = pointMaterial;
-    }
-  }
-  const polylines = primitive.polylines;
-  if (polylines && polylineMaterial) {
-    for (let i = 0; i < polylines.length; i++) {
-      polylines.get(i).material = polylineMaterial;
-    }
-  }
-  const polygons = primitive.polygons;
-  if (polygons && polygonMaterial) {
-    for (let i = 0; i < polygons.length; i++) {
-      polygons.get(i).material = polygonMaterial;
+  // Cesium's BufferPrimitiveCollection.get(index, result) writes onto a
+  // reusable BufferPrimitive cursor — this is the documented iteration shape.
+  const cursor = new BufferPrimitive();
+  const collections = [
+    [primitive.points, pointMaterial] as const,
+    [primitive.polylines, polylineMaterial] as const,
+    [primitive.polygons, polygonMaterial] as const,
+  ];
+  for (const [collection, material] of collections) {
+    if (!collection || !material) continue;
+    // primitiveCount is the public count getter on BufferPrimitiveCollection —
+    // its d.ts surface omits `length`/`size`/array indexing.
+    const count = (collection as unknown as { primitiveCount: number }).primitiveCount;
+    for (let i = 0; i < count; i++) {
+      collection.get(i, cursor);
+      cursor.setMaterial(material);
     }
   }
 }

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.test.ts
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.test.ts
@@ -1,0 +1,38 @@
+import type { TypeEqual } from "ts-expect";
+import { expectType } from "ts-expect";
+import { it } from "vitest";
+
+import type { UnusedCesiumProps } from "../core";
+
+import type {
+  GeoJsonPrimitiveCesiumReadonlyProps,
+  GeoJsonPrimitiveOtherProps,
+  GeoJsonPrimitiveProps,
+  GeoJsonPrimitiveShape,
+} from "./GeoJsonPrimitive";
+
+// Unused prop check
+type UnusedProps = UnusedCesiumProps<
+  GeoJsonPrimitiveShape,
+  Omit<
+    GeoJsonPrimitiveProps,
+    keyof GeoJsonPrimitiveOtherProps | keyof GeoJsonPrimitiveCesiumReadonlyProps
+  >,
+  {},
+  IgnoredProps
+>;
+// Internal-only/getter-only props consumers reach via ref, not as wrapper props:
+// - points/polylines/polygons: read-only getters exposing the internal Buffer collections
+// - featureCount/ids/properties/url: read-only metadata
+type IgnoredProps =
+  | "points"
+  | "polylines"
+  | "polygons"
+  | "featureCount"
+  | "ids"
+  | "properties"
+  | "url";
+
+expectType<TypeEqual<never, UnusedProps>>(true);
+
+it("should be compiled", () => {});

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
@@ -9,7 +9,7 @@ import { createCesiumComponent, useSuspendedResource } from "../core";
 // node_modules/cesium/Source/Cesium.d.ts ~L34084-34124. The runtime members
 // exist in GeoJsonPrimitive.js (constructor ~L79, destroy ~L352). Augment
 // locally so PickCesiumProps can reflect `show` as a live wrapper prop.
-type GeoJsonPrimitiveShape = CesiumGeoJsonPrimitive & { show: boolean };
+export type GeoJsonPrimitiveShape = CesiumGeoJsonPrimitive & { show: boolean };
 
 /*
 @summary

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
@@ -1,0 +1,130 @@
+import { GeoJsonPrimitive as CesiumGeoJsonPrimitive, Resource } from "cesium";
+
+import type { EventProps, PickCesiumProps, SuspenseProps } from "../core";
+import { createCesiumComponent, useSuspendedResource } from "../core";
+
+// Cesium 1.142 ships `GeoJsonPrimitive` as @experimental and its .d.ts omits the
+// runtime instance properties (notably `show`) from the class shape. Augment
+// locally so PickCesiumProps can reflect `show` as a live wrapper prop.
+type GeoJsonPrimitiveShape = CesiumGeoJsonPrimitive & { show: boolean };
+
+/*
+@summary
+`GeoJsonPrimitive` is a high-throughput companion to `GeoJsonDataSource` that
+loads GeoJSON directly into `BufferPointCollection`/`BufferPolylineCollection`/
+`BufferPolygonCollection`, bypassing the entity/DataSource layer.
+
+This API is experimental and subject to change without standard deprecation.
+*/
+
+/*
+@scope
+Inside [Viewer](/components/Viewer) or [CesiumWidget](/components/CesiumWidget) component.
+A GeoJsonPrimitive object will be attached to the PrimitiveCollection of the Viewer or CesiumWidget.
+*/
+
+export type GeoJsonPrimitiveCesiumProps = PickCesiumProps<
+  GeoJsonPrimitiveShape,
+  typeof cesiumProps
+>;
+
+export type GeoJsonPrimitiveCesiumReadonlyProps = {
+  /** Ellipsoid used to project GeoJSON coordinates. Fixed at creation time. */
+  ellipsoid?: ConstructorParameters<typeof CesiumGeoJsonPrimitive>[0] extends infer O
+    ? O extends { ellipsoid?: infer E }
+      ? E
+      : never
+    : never;
+  /** Whether features in the primitive can be picked. Fixed at creation time. */
+  allowPicking?: boolean;
+  /** Factory invoked to build the picked-object payload. Fixed at creation time. */
+  pickObjectFactory?: ConstructorParameters<typeof CesiumGeoJsonPrimitive>[0] extends infer O
+    ? O extends { pickObjectFactory?: infer F }
+      ? F
+      : never
+    : never;
+};
+
+export type GeoJsonPrimitiveOtherProps = EventProps<unknown> &
+  SuspenseProps & {
+    /** URL to fetch GeoJSON from. Mutually exclusive with `data` — if both are set, `url` wins. */
+    url?: string | Resource;
+    /** Inline GeoJSON FeatureCollection. Mutually exclusive with `url`. */
+    data?: object;
+    /** Fires once the primitive is constructed and added to the scene. */
+    onReady?: (primitive: GeoJsonPrimitiveShape) => void;
+    /** Fires if `fromUrl` rejects or the inline GeoJSON fails to parse. */
+    onError?: (err: unknown) => void;
+  };
+
+export type GeoJsonPrimitiveProps = GeoJsonPrimitiveCesiumProps &
+  GeoJsonPrimitiveCesiumReadonlyProps &
+  GeoJsonPrimitiveOtherProps;
+
+const cesiumProps = ["show"] as const;
+
+const cesiumReadonlyProps = ["ellipsoid", "allowPicking", "pickObjectFactory"] as const;
+
+export const otherProps = ["url", "data", "onReady", "onError", "suspense", "cacheKey"] as const;
+
+const useResource = (
+  props: GeoJsonPrimitiveProps,
+): Partial<GeoJsonPrimitiveProps> | undefined => {
+  const resolved = useSuspendedResource("geojson-primitive", props.url ?? props.data, props, url =>
+    Resource.fetchJson({ url }),
+  );
+  return resolved ? { data: resolved as object } : undefined;
+};
+
+const GeoJsonPrimitive = createCesiumComponent<GeoJsonPrimitiveShape, GeoJsonPrimitiveProps>({
+  name: "GeoJsonPrimitive",
+  async create(context, props) {
+    if (!context.primitiveCollection) return;
+
+    const { url, data, ellipsoid, allowPicking, pickObjectFactory, show, onReady, onError } = props;
+
+    let element: GeoJsonPrimitiveShape;
+    try {
+      if (url) {
+        element = (await (CesiumGeoJsonPrimitive as unknown as {
+          fromUrl: (
+            url: string | Resource,
+            options?: Record<string, unknown>,
+          ) => Promise<CesiumGeoJsonPrimitive>;
+        }).fromUrl(url, { ellipsoid, allowPicking, pickObjectFactory, show })) as GeoJsonPrimitiveShape;
+      } else if (data) {
+        element = new CesiumGeoJsonPrimitive({
+          geoJson: data,
+          ellipsoid,
+          allowPicking,
+          pickObjectFactory,
+          show,
+        } as ConstructorParameters<typeof CesiumGeoJsonPrimitive>[0]) as GeoJsonPrimitiveShape;
+      } else {
+        return;
+      }
+      onReady?.(element);
+    } catch (e) {
+      onError?.(e);
+      return;
+    }
+
+    context.primitiveCollection.add(element);
+    return element;
+  },
+  destroy(element, context) {
+    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
+      // PrimitiveCollection.remove() handles cleanup; GeoJsonPrimitive (Cesium 1.142,
+      // experimental) does not expose an explicit destroy()/isDestroyed() surface in
+      // its d.ts.
+      context.primitiveCollection.remove(element);
+    }
+  },
+  useResource,
+  cesiumProps,
+  cesiumReadonlyProps,
+  otherProps,
+  useCommonEvent: true,
+});
+
+export default GeoJsonPrimitive;

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
@@ -1,10 +1,13 @@
 import { GeoJsonPrimitive as CesiumGeoJsonPrimitive, Resource } from "cesium";
+import type { GeoJsonPrimitiveConstructorOptions } from "cesium";
 
 import type { EventProps, PickCesiumProps, SuspenseProps } from "../core";
 import { createCesiumComponent, useSuspendedResource } from "../core";
 
 // Cesium 1.142 ships `GeoJsonPrimitive` as @experimental and its .d.ts omits the
-// runtime instance properties (notably `show`) from the class shape. Augment
+// runtime instance properties (notably `show`) from the class shape — see
+// node_modules/cesium/Source/Cesium.d.ts ~L34084-34124. The runtime members
+// exist in GeoJsonPrimitive.js (constructor ~L79, destroy ~L352). Augment
 // locally so PickCesiumProps can reflect `show` as a live wrapper prop.
 type GeoJsonPrimitiveShape = CesiumGeoJsonPrimitive & { show: boolean };
 
@@ -30,19 +33,11 @@ export type GeoJsonPrimitiveCesiumProps = PickCesiumProps<
 
 export type GeoJsonPrimitiveCesiumReadonlyProps = {
   /** Ellipsoid used to project GeoJSON coordinates. Fixed at creation time. */
-  ellipsoid?: ConstructorParameters<typeof CesiumGeoJsonPrimitive>[0] extends infer O
-    ? O extends { ellipsoid?: infer E }
-      ? E
-      : never
-    : never;
+  ellipsoid?: GeoJsonPrimitiveConstructorOptions["ellipsoid"];
   /** Whether features in the primitive can be picked. Fixed at creation time. */
   allowPicking?: boolean;
   /** Factory invoked to build the picked-object payload. Fixed at creation time. */
-  pickObjectFactory?: ConstructorParameters<typeof CesiumGeoJsonPrimitive>[0] extends infer O
-    ? O extends { pickObjectFactory?: infer F }
-      ? F
-      : never
-    : never;
+  pickObjectFactory?: GeoJsonPrimitiveConstructorOptions["pickObjectFactory"];
 };
 
 export type GeoJsonPrimitiveOtherProps = EventProps<unknown> &
@@ -65,6 +60,13 @@ const cesiumProps = ["show"] as const;
 
 const cesiumReadonlyProps = ["ellipsoid", "allowPicking", "pickObjectFactory"] as const;
 
+// `url` and `data` are user-supplied props (not real Cesium properties), but
+// they are treated as read-only so that changing either at runtime makes the
+// core destroy and recreate the primitive. They are NOT added to the typed
+// `GeoJsonPrimitiveCesiumReadonlyProps` (they live in `OtherProps`) — this
+// const is just the runtime trigger list.
+const cesiumReadonlyPropsWithUrlOrData = [...cesiumReadonlyProps, "url", "data"] as const;
+
 export const otherProps = ["url", "data", "onReady", "onError", "suspense", "cacheKey"] as const;
 
 const useResource = (
@@ -73,7 +75,9 @@ const useResource = (
   const resolved = useSuspendedResource("geojson-primitive", props.url ?? props.data, props, url =>
     Resource.fetchJson({ url }),
   );
-  return resolved ? { data: resolved as object } : undefined;
+  // When Suspense has resolved a URL into JSON, drop `url` so create() takes the
+  // synchronous `data` path instead of refetching via fromUrl().
+  return resolved ? { data: resolved as object, url: undefined } : undefined;
 };
 
 const GeoJsonPrimitive = createCesiumComponent<GeoJsonPrimitiveShape, GeoJsonPrimitiveProps>({
@@ -86,12 +90,12 @@ const GeoJsonPrimitive = createCesiumComponent<GeoJsonPrimitiveShape, GeoJsonPri
     let element: GeoJsonPrimitiveShape;
     try {
       if (url) {
-        element = (await (CesiumGeoJsonPrimitive as unknown as {
-          fromUrl: (
-            url: string | Resource,
-            options?: Record<string, unknown>,
-          ) => Promise<CesiumGeoJsonPrimitive>;
-        }).fromUrl(url, { ellipsoid, allowPicking, pickObjectFactory, show })) as GeoJsonPrimitiveShape;
+        element = (await CesiumGeoJsonPrimitive.fromUrl(url, {
+          ellipsoid,
+          allowPicking,
+          pickObjectFactory,
+          show,
+        })) as GeoJsonPrimitiveShape;
       } else if (data) {
         element = new CesiumGeoJsonPrimitive({
           geoJson: data,
@@ -99,7 +103,7 @@ const GeoJsonPrimitive = createCesiumComponent<GeoJsonPrimitiveShape, GeoJsonPri
           allowPicking,
           pickObjectFactory,
           show,
-        } as ConstructorParameters<typeof CesiumGeoJsonPrimitive>[0]) as GeoJsonPrimitiveShape;
+        } as GeoJsonPrimitiveConstructorOptions) as GeoJsonPrimitiveShape;
       } else {
         return;
       }
@@ -122,7 +126,7 @@ const GeoJsonPrimitive = createCesiumComponent<GeoJsonPrimitiveShape, GeoJsonPri
   },
   useResource,
   cesiumProps,
-  cesiumReadonlyProps,
+  cesiumReadonlyProps: cesiumReadonlyPropsWithUrlOrData,
   otherProps,
   useCommonEvent: true,
 });

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.ts
@@ -46,7 +46,7 @@ export type GeoJsonPrimitiveOtherProps = EventProps<unknown> &
     url?: string | Resource;
     /** Inline GeoJSON FeatureCollection. Mutually exclusive with `url`. */
     data?: object;
-    /** Fires once the primitive is constructed and added to the scene. */
+    /** Fires once the primitive is constructed, before it is attached to the scene's primitive collection. */
     onReady?: (primitive: GeoJsonPrimitiveShape) => void;
     /** Fires if `fromUrl` rejects or the inline GeoJSON fails to parse. */
     onError?: (err: unknown) => void;

--- a/src/GeoJsonPrimitive/GeoJsonPrimitive.vrt.stories.tsx
+++ b/src/GeoJsonPrimitive/GeoJsonPrimitive.vrt.stories.tsx
@@ -1,0 +1,62 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Cartesian3 } from "cesium";
+
+import CameraFlyTo from "../CameraFlyTo";
+import VrtViewer from "../__vrt__/VrtViewer";
+
+import GeoJsonPrimitive from "./GeoJsonPrimitive";
+
+type Story = StoryObj<typeof GeoJsonPrimitive>;
+
+const inlineGeoJson = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [-95.0, 40.0] },
+      properties: {},
+    },
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-96.0, 39.5],
+          [-94.0, 40.5],
+        ],
+      },
+      properties: {},
+    },
+    {
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-95.6, 39.8],
+            [-94.4, 39.8],
+            [-94.4, 40.2],
+            [-95.6, 40.2],
+            [-95.6, 39.8],
+          ],
+        ],
+      },
+      properties: {},
+    },
+  ],
+};
+
+export default {
+  title: "VRT/GeoJsonPrimitive",
+  component: GeoJsonPrimitive,
+  tags: ["vrt"],
+} as Meta;
+
+export const Default: Story = {
+  render: () => (
+    <VrtViewer>
+      <CameraFlyTo destination={Cartesian3.fromDegrees(-95.0, 40.0, 1_500_000)} duration={0} />
+      <GeoJsonPrimitive data={inlineGeoJson} />
+    </VrtViewer>
+  ),
+};

--- a/src/GeoJsonPrimitive/index.ts
+++ b/src/GeoJsonPrimitive/index.ts
@@ -1,0 +1,1 @@
+export { default, type GeoJsonPrimitiveProps } from "./GeoJsonPrimitive";

--- a/src/GeoJsonPrimitive/index.ts
+++ b/src/GeoJsonPrimitive/index.ts
@@ -1,1 +1,5 @@
-export { default, type GeoJsonPrimitiveProps } from "./GeoJsonPrimitive";
+export {
+  default,
+  type GeoJsonPrimitiveProps,
+  type GeoJsonPrimitiveShape,
+} from "./GeoJsonPrimitive";

--- a/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.stories.tsx
+++ b/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.stories.tsx
@@ -14,18 +14,74 @@ type Story = StoryObj<typeof GooglePhotorealistic3DTileset>;
 export default {
   title: "GooglePhotorealistic3DTileset",
   component: GooglePhotorealistic3DTileset,
+  argTypes: {
+    apiKey: {
+      control: "text",
+      description:
+        "Google Maps API key. Required to load photorealistic tiles. Paste your own key in the Storybook controls panel — none is shipped in source.",
+    },
+  },
 } as Meta;
 
-// An API key may be required to load Google Photorealistic 3D Tiles.
-// Set it globally via `Cesium.GoogleMaps.defaultApiKey` or pass the `apiKey` prop.
+/**
+ * Loads Google's photorealistic 3D tiles using the `apiKey` arg.
+ *
+ * **Bring your own API key.** No key is shipped in the repo. Paste a Google
+ * Maps API key into the `apiKey` control to mount the tileset. Without a key
+ * the tileset request hangs waiting for authentication and the iframe locks up;
+ * the story handles this by showing an instructional empty-state overlay until
+ * a key is provided.
+ *
+ * Get a key at https://console.cloud.google.com → APIs & Services → Credentials,
+ * then enable the "Map Tiles API" and the "Photorealistic 3D Tiles" capability.
+ */
 export const Basic: Story = {
+  args: {
+    // Empty by default — paste your Google Maps API key into the controls panel.
+    // See the JSDoc above for why no default key is shipped.
+    apiKey: "",
+  },
   render: args => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const ref = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    if (!args.apiKey) {
+      return (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#111",
+            color: "white",
+            fontFamily: "monospace",
+            padding: 24,
+            textAlign: "center",
+          }}>
+          <div style={{ maxWidth: 540 }}>
+            <p style={{ fontSize: 16, marginBottom: 16 }}>
+              Paste your Google Maps API key into the <code>apiKey</code>{" "}
+              control to load the photorealistic tileset.
+            </p>
+            <p style={{ opacity: 0.8, fontSize: 13, lineHeight: 1.5 }}>
+              Without a key, Cesium's authentication handshake hangs waiting
+              for credentials and the iframe locks up.
+            </p>
+            <p style={{ opacity: 0.6, fontSize: 12, lineHeight: 1.5, marginTop: 16 }}>
+              Get a key at{" "}
+              <code>console.cloud.google.com → APIs & Services → Credentials</code>,
+              enable the <em>Map Tiles API</em>, then paste it above.
+            </p>
+          </div>
+        </div>
+      );
+    }
     return (
       <Viewer full ref={ref}>
         <GooglePhotorealistic3DTileset
           {...args}
+          apiKey={args.apiKey}
           onAllTilesLoad={action("onAllTilesLoad")}
           onInitialTilesLoad={action("onInitialTilesLoad")}
           onTileFailed={action("onTileFailed")}

--- a/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.ts
+++ b/src/GooglePhotorealistic3DTileset/GooglePhotorealistic3DTileset.ts
@@ -111,6 +111,7 @@ const cesiumProps = [
   "dynamicScreenSpaceErrorDensity",
   "dynamicScreenSpaceErrorFactor",
   "dynamicScreenSpaceErrorHeightFalloff",
+  "edgeDisplayMode",
   "skipLevelOfDetail",
   "baseScreenSpaceError",
   "skipScreenSpaceErrorFactor",

--- a/src/MVTDataProvider/MVTDataProvider.stories.tsx
+++ b/src/MVTDataProvider/MVTDataProvider.stories.tsx
@@ -1,0 +1,46 @@
+import { action } from "storybook/actions";
+import { Meta, StoryObj } from "@storybook/react";
+import { Cartesian3, Viewer as CesiumViewer } from "cesium";
+import { useRef } from "react";
+
+import { CesiumComponentRef } from "../core";
+import Viewer from "../Viewer";
+
+import MVTDataProvider from "./MVTDataProvider";
+
+type Story = StoryObj<typeof MVTDataProvider>;
+
+export default {
+  title: "MVTDataProvider",
+  component: MVTDataProvider,
+} as Meta;
+
+/**
+ * Loads a public MVT endpoint and shows the resulting tileset over a global view.
+ * Network-dependent — does not run under VRT (no `vrt` tag).
+ */
+export const Basic: Story = {
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const viewerRef = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    return (
+      <Viewer full ref={viewerRef}>
+        <MVTDataProvider
+          {...args}
+          // Public Protomaps MVT endpoint — no API key required.
+          url="https://api.protomaps.com/tiles/v3/{z}/{x}/{y}.mvt"
+          maxZoom={14}
+          onReady={provider => {
+            action("onReady")(provider);
+            // Fly to a global view so the tileset extent is visible regardless of where it loads first.
+            viewerRef.current?.cesiumElement?.camera.flyTo({
+              destination: Cartesian3.fromDegrees(0, 0, 25_000_000),
+              duration: 0,
+            });
+          }}
+          onError={action("onError")}
+        />
+      </Viewer>
+    );
+  },
+};

--- a/src/MVTDataProvider/MVTDataProvider.stories.tsx
+++ b/src/MVTDataProvider/MVTDataProvider.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import {
   Cartesian3,
   Cesium3DTileStyle,
+  Math as CesiumMath,
   Rectangle,
   Viewer as CesiumViewer,
 } from "cesium";
@@ -32,15 +33,61 @@ export default {
 // Without an `extent`, Cesium's tile-selection traverses the whole world tree
 // and pegs the iframe even on modest datasets — see the JSDoc on `Basic` below.
 const NYC_EXTENT = Rectangle.fromDegrees(-74.05, 40.65, -73.85, 40.85);
-const NYC_VIEW = Cartesian3.fromDegrees(-73.95, 40.75, 50_000);
+
+// Oblique camera over lower Manhattan looking north — shows the 3D extruded
+// buildings (OpenMapTiles' building features carry a `height` property; the
+// MVT→3D Tiles conversion preserves it) rather than a flat top-down blob.
+const NYC_VIEW = Cartesian3.fromDegrees(-74.0, 40.68, 2500);
+const NYC_ORIENTATION = {
+  heading: 0,
+  pitch: CesiumMath.toRadians(-25),
+  roll: 0,
+};
+
+// Per-feature-class styling built around OpenMapTiles' `class` property
+// (preserved through the MVT→3D Tiles conversion as EXT_structural_metadata
+// per the 1.142 changelog). Without this, every feature comes through with
+// no visible fill and the viewer renders an empty tile tree.
+const VECTOR_TILE_STYLE = new Cesium3DTileStyle({
+  color: {
+    conditions: [
+      // Buildings get a warm tan; alpha=1 so extrusions read as solid
+      ["${class} === 'building'", "color('#bcaa90', 1.0)"],
+      // Water layers (ocean, river, lake, sea, bay)
+      [
+        "regExp('^(water|ocean|river|lake|sea|bay|stream)$').test(${class})",
+        "color('#3892c4', 0.85)",
+      ],
+      // Green spaces (park, wood, forest, grass, farmland, cemetery)
+      [
+        "regExp('^(park|wood|forest|grass|farmland|cemetery|playground|garden|nature_reserve)$').test(${class})",
+        "color('#7cc26b', 0.7)",
+      ],
+      // Major roads (motorway, trunk, primary, secondary, tertiary)
+      [
+        "regExp('^(motorway|trunk|primary|secondary|tertiary|major)$').test(${class})",
+        "color('#fbd870', 0.95)",
+      ],
+      // Built-up urban landuse
+      [
+        "regExp('^(residential|commercial|industrial|retail|school|hospital|university)$').test(${class})",
+        "color('#dec8a8', 0.55)",
+      ],
+      // Default: light beige (fallback for unclassified features)
+      ["true", "color('#e8d8c0', 0.45)"],
+    ],
+  },
+});
 
 /**
  * Loads OpenFreeMap's OpenMapTiles dataset for the Manhattan area and renders
- * features with a visible blue style.
+ * features styled per OpenMapTiles `class` (water blue, parks green, buildings
+ * tan, major roads yellow, urban landuse beige). Camera is an oblique view from
+ * lower Manhattan looking north so 3D-extruded building footprints are visible.
  *
  * **About the constraints:** Cesium 1.142's `MVTDataProvider` is `@experimental`
- * and not yet performance-tuned for planet-scale rendering. Two constraints are
- * required for a smooth demo:
+ * and not yet performance-tuned for planet-scale rendering. Three things are
+ * required for a useful demo:
  *
  * 1. **`extent`** — restrict the tile tree to a small geographic region.
  *    Without this, Cesium fetches tiles across the whole globe and the iframe
@@ -48,6 +95,8 @@ const NYC_VIEW = Cartesian3.fromDegrees(-73.95, 40.75, 50_000);
  * 2. **`Cesium3DTileStyle`** — apply per-feature color/show via the internal
  *    tileset (reached through `getTileset(provider)`). Without a style,
  *    decoded MVT features have no visible fill and you see nothing.
+ * 3. **Oblique camera** — a top-down view collapses 3D buildings into flat
+ *    polygons; pitching the camera shows the extrusion.
  *
  * Paste a different `{z}/{x}/{y}` MVT URL into the `url` control to swap data
  * sources (e.g. your MapTiler/Mapbox key URL). Network-dependent — does not
@@ -104,13 +153,11 @@ export const Basic: Story = {
             action("onReady")(provider);
             const tileset = getTileset(provider);
             if (tileset) {
-              tileset.style = new Cesium3DTileStyle({
-                color: "color('#3388ff', 0.6)",
-                show: true,
-              });
+              tileset.style = VECTOR_TILE_STYLE;
             }
             viewerRef.current?.cesiumElement?.camera.flyTo({
               destination: NYC_VIEW,
+              orientation: NYC_ORIENTATION,
               duration: 0,
             });
           }}

--- a/src/MVTDataProvider/MVTDataProvider.stories.tsx
+++ b/src/MVTDataProvider/MVTDataProvider.stories.tsx
@@ -23,22 +23,23 @@ export default {
 } as Meta;
 
 /**
- * Loads a public MVT endpoint and shows the resulting tileset over a global view.
+ * Bring-your-own-URL demo for `MVTDataProvider`. Paste a `{z}/{x}/{y}` MVT URL
+ * (with API key if your provider requires one) into the `url` control to mount
+ * the wrapper against real tiles.
  *
- * Defaults to MapLibre's curated demo basemap (no API key required, public test dataset).
- * To test against your own tiles, paste a `{z}/{x}/{y}.pbf|.mvt` URL into the
- * `url` control — most production vector tile services (Mapbox, MapTiler,
- * Protomaps, ESRI) require an API key in the URL.
+ * No default URL is shipped because every free public MVT endpoint we evaluated
+ * is fragile — Protomaps' demo path now returns 403, MapLibre's demotiles is
+ * only z0–z5 and crashes the browser at higher zoom, OpenFreeMap is a
+ * community-hosted endpoint that can rotate. This mirrors how the
+ * `GooglePhotorealistic3DTileset` story expects consumers to bring their own
+ * API key.
  *
  * Network-dependent — does not run under VRT (no `vrt` tag).
  */
 export const Basic: Story = {
   args: {
-    // MapLibre's demo basemap — public test dataset specifically for examples like this.
-    // If MapLibre rotates this URL, swap to e.g.
-    //   https://tiles.openfreemap.org/planet/20240429_001001_pt/{z}/{x}/{y}.pbf
-    // or paste your own keyed URL via the controls panel.
-    url: "https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf",
+    // Empty by default — see the JSDoc above for why. Paste your own URL in the controls panel.
+    url: "",
     maxZoom: 14,
   },
   render: args => {
@@ -59,10 +60,22 @@ export const Basic: Story = {
             padding: 24,
             textAlign: "center",
           }}>
-          <div>
-            <p>Paste an MVT URL into the <code>url</code> control to test the wrapper.</p>
-            <p style={{ opacity: 0.7, fontSize: 12, marginTop: 12 }}>
-              Example: <code>{"https://your-host.example/tiles/{z}/{x}/{y}.pbf?key=YOUR_KEY"}</code>
+          <div style={{ maxWidth: 540 }}>
+            <p style={{ fontSize: 16, marginBottom: 16 }}>
+              Paste an MVT URL into the <code>url</code> control to mount the
+              wrapper against real tiles.
+            </p>
+            <p style={{ opacity: 0.8, fontSize: 13, lineHeight: 1.5 }}>
+              Example shape (your endpoint and key):
+              <br />
+              <code>{"https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf?key=YOUR_KEY"}</code>
+            </p>
+            <p style={{ opacity: 0.6, fontSize: 12, lineHeight: 1.5, marginTop: 16 }}>
+              No default URL is shipped — every free public MVT endpoint we
+              evaluated either requires authentication or proved unstable. This
+              mirrors how the <code>GooglePhotorealistic3DTileset</code> story
+              expects you to set <code>GoogleMaps.defaultApiKey</code> or pass
+              an <code>apiKey</code> prop.
             </p>
           </div>
         </div>

--- a/src/MVTDataProvider/MVTDataProvider.stories.tsx
+++ b/src/MVTDataProvider/MVTDataProvider.stories.tsx
@@ -23,23 +23,22 @@ export default {
 } as Meta;
 
 /**
- * Bring-your-own-URL demo for `MVTDataProvider`. Paste a `{z}/{x}/{y}` MVT URL
- * (with API key if your provider requires one) into the `url` control to mount
- * the wrapper against real tiles.
+ * Loads OpenFreeMap's planet-scale OpenMapTiles vector tile set by default and
+ * renders it over the Cesium globe. Paste a different `{z}/{x}/{y}` MVT URL
+ * (e.g. your MapTiler/Mapbox key URL) into the `url` control to swap data sources.
  *
- * No default URL is shipped because every free public MVT endpoint we evaluated
- * is fragile — Protomaps' demo path now returns 403, MapLibre's demotiles is
- * only z0–z5 and crashes the browser at higher zoom, OpenFreeMap is a
- * community-hosted endpoint that can rotate. This mirrors how the
- * `GooglePhotorealistic3DTileset` story expects consumers to bring their own
- * API key.
+ * The default URL (`tiles.openfreemap.org/planet/latest/`) is OpenFreeMap's
+ * officially-stable `latest` alias against the OpenMapTiles schema, full zoom
+ * coverage z0–z14, no API key. Falls back to a bring-your-own-URL empty state
+ * if you clear the `url` arg.
  *
  * Network-dependent — does not run under VRT (no `vrt` tag).
  */
 export const Basic: Story = {
   args: {
-    // Empty by default — see the JSDoc above for why. Paste your own URL in the controls panel.
-    url: "",
+    // OpenFreeMap planet/latest alias — public OpenMapTiles dataset, no API key required,
+    // documented as the stable alias by the OpenFreeMap project (https://openfreemap.org).
+    url: "https://tiles.openfreemap.org/planet/latest/{z}/{x}/{y}.pbf",
     maxZoom: 14,
   },
   render: args => {
@@ -71,11 +70,9 @@ export const Basic: Story = {
               <code>{"https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf?key=YOUR_KEY"}</code>
             </p>
             <p style={{ opacity: 0.6, fontSize: 12, lineHeight: 1.5, marginTop: 16 }}>
-              No default URL is shipped — every free public MVT endpoint we
-              evaluated either requires authentication or proved unstable. This
-              mirrors how the <code>GooglePhotorealistic3DTileset</code> story
-              expects you to set <code>GoogleMaps.defaultApiKey</code> or pass
-              an <code>apiKey</code> prop.
+              The story ships with an OpenFreeMap default; clear the URL arg
+              to see this overlay, or paste your own keyed URL (Mapbox,
+              MapTiler, Protomaps, etc.) to test against your provider.
             </p>
           </div>
         </div>

--- a/src/MVTDataProvider/MVTDataProvider.stories.tsx
+++ b/src/MVTDataProvider/MVTDataProvider.stories.tsx
@@ -13,23 +13,66 @@ type Story = StoryObj<typeof MVTDataProvider>;
 export default {
   title: "MVTDataProvider",
   component: MVTDataProvider,
+  argTypes: {
+    url: {
+      control: "text",
+      description:
+        "MVT URL template ({z}/{x}/{y}). Most production vector tile services require an API key — paste your own key URL here to test against a known dataset.",
+    },
+  },
 } as Meta;
 
 /**
  * Loads a public MVT endpoint and shows the resulting tileset over a global view.
+ *
+ * Defaults to MapLibre's curated demo basemap (no API key required, public test dataset).
+ * To test against your own tiles, paste a `{z}/{x}/{y}.pbf|.mvt` URL into the
+ * `url` control — most production vector tile services (Mapbox, MapTiler,
+ * Protomaps, ESRI) require an API key in the URL.
+ *
  * Network-dependent — does not run under VRT (no `vrt` tag).
  */
 export const Basic: Story = {
+  args: {
+    // MapLibre's demo basemap — public test dataset specifically for examples like this.
+    // If MapLibre rotates this URL, swap to e.g.
+    //   https://tiles.openfreemap.org/planet/20240429_001001_pt/{z}/{x}/{y}.pbf
+    // or paste your own keyed URL via the controls panel.
+    url: "https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf",
+    maxZoom: 14,
+  },
   render: args => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const viewerRef = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    if (!args.url) {
+      return (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#111",
+            color: "white",
+            fontFamily: "monospace",
+            padding: 24,
+            textAlign: "center",
+          }}>
+          <div>
+            <p>Paste an MVT URL into the <code>url</code> control to test the wrapper.</p>
+            <p style={{ opacity: 0.7, fontSize: 12, marginTop: 12 }}>
+              Example: <code>{"https://your-host.example/tiles/{z}/{x}/{y}.pbf?key=YOUR_KEY"}</code>
+            </p>
+          </div>
+        </div>
+      );
+    }
     return (
       <Viewer full ref={viewerRef}>
         <MVTDataProvider
           {...args}
-          // Public Protomaps MVT endpoint — no API key required.
-          url="https://api.protomaps.com/tiles/v3/{z}/{x}/{y}.mvt"
-          maxZoom={14}
+          url={args.url}
           onReady={provider => {
             action("onReady")(provider);
             // Fly to a global view so the tileset extent is visible regardless of where it loads first.

--- a/src/MVTDataProvider/MVTDataProvider.stories.tsx
+++ b/src/MVTDataProvider/MVTDataProvider.stories.tsx
@@ -1,12 +1,17 @@
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react";
-import { Cartesian3, Viewer as CesiumViewer } from "cesium";
+import {
+  Cartesian3,
+  Cesium3DTileStyle,
+  Rectangle,
+  Viewer as CesiumViewer,
+} from "cesium";
 import { useRef } from "react";
 
 import { CesiumComponentRef } from "../core";
 import Viewer from "../Viewer";
 
-import MVTDataProvider from "./MVTDataProvider";
+import MVTDataProvider, { getTileset } from "./MVTDataProvider";
 
 type Story = StoryObj<typeof MVTDataProvider>;
 
@@ -22,24 +27,36 @@ export default {
   },
 } as Meta;
 
+// Constrain the demo to a small area (Manhattan, NYC) so the experimental
+// MVTDataProvider doesn't try to load planet-scale data into the browser.
+// Without an `extent`, Cesium's tile-selection traverses the whole world tree
+// and pegs the iframe even on modest datasets — see the JSDoc on `Basic` below.
+const NYC_EXTENT = Rectangle.fromDegrees(-74.05, 40.65, -73.85, 40.85);
+const NYC_VIEW = Cartesian3.fromDegrees(-73.95, 40.75, 50_000);
+
 /**
- * Loads OpenFreeMap's planet-scale OpenMapTiles vector tile set by default and
- * renders it over the Cesium globe. Paste a different `{z}/{x}/{y}` MVT URL
- * (e.g. your MapTiler/Mapbox key URL) into the `url` control to swap data sources.
+ * Loads OpenFreeMap's OpenMapTiles dataset for the Manhattan area and renders
+ * features with a visible blue style.
  *
- * The default URL (`tiles.openfreemap.org/planet/latest/`) is OpenFreeMap's
- * officially-stable `latest` alias against the OpenMapTiles schema, full zoom
- * coverage z0–z14, no API key. Falls back to a bring-your-own-URL empty state
- * if you clear the `url` arg.
+ * **About the constraints:** Cesium 1.142's `MVTDataProvider` is `@experimental`
+ * and not yet performance-tuned for planet-scale rendering. Two constraints are
+ * required for a smooth demo:
  *
- * Network-dependent — does not run under VRT (no `vrt` tag).
+ * 1. **`extent`** — restrict the tile tree to a small geographic region.
+ *    Without this, Cesium fetches tiles across the whole globe and the iframe
+ *    becomes unresponsive.
+ * 2. **`Cesium3DTileStyle`** — apply per-feature color/show via the internal
+ *    tileset (reached through `getTileset(provider)`). Without a style,
+ *    decoded MVT features have no visible fill and you see nothing.
+ *
+ * Paste a different `{z}/{x}/{y}` MVT URL into the `url` control to swap data
+ * sources (e.g. your MapTiler/Mapbox key URL). Network-dependent — does not
+ * run under VRT.
  */
 export const Basic: Story = {
   args: {
-    // OpenFreeMap planet/latest alias — public OpenMapTiles dataset, no API key required,
-    // documented as the stable alias by the OpenFreeMap project (https://openfreemap.org).
     url: "https://tiles.openfreemap.org/planet/latest/{z}/{x}/{y}.pbf",
-    maxZoom: 14,
+    maxZoom: 12,
   },
   render: args => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -70,9 +87,8 @@ export const Basic: Story = {
               <code>{"https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf?key=YOUR_KEY"}</code>
             </p>
             <p style={{ opacity: 0.6, fontSize: 12, lineHeight: 1.5, marginTop: 16 }}>
-              The story ships with an OpenFreeMap default; clear the URL arg
-              to see this overlay, or paste your own keyed URL (Mapbox,
-              MapTiler, Protomaps, etc.) to test against your provider.
+              The story ships with an OpenFreeMap default + Manhattan extent;
+              clear the URL arg to see this overlay.
             </p>
           </div>
         </div>
@@ -83,11 +99,18 @@ export const Basic: Story = {
         <MVTDataProvider
           {...args}
           url={args.url}
+          extent={NYC_EXTENT}
           onReady={provider => {
             action("onReady")(provider);
-            // Fly to a global view so the tileset extent is visible regardless of where it loads first.
+            const tileset = getTileset(provider);
+            if (tileset) {
+              tileset.style = new Cesium3DTileStyle({
+                color: "color('#3388ff', 0.6)",
+                show: true,
+              });
+            }
             viewerRef.current?.cesiumElement?.camera.flyTo({
-              destination: Cartesian3.fromDegrees(0, 0, 25_000_000),
+              destination: NYC_VIEW,
               duration: 0,
             });
           }}

--- a/src/MVTDataProvider/MVTDataProvider.test.ts
+++ b/src/MVTDataProvider/MVTDataProvider.test.ts
@@ -1,0 +1,34 @@
+import type { TypeEqual } from "ts-expect";
+import { expectType } from "ts-expect";
+import { it } from "vitest";
+
+import type { UnusedCesiumProps } from "../core";
+
+import type {
+  MVTDataProviderCesiumReadonlyProps,
+  MVTDataProviderOtherProps,
+  MVTDataProviderProps,
+  MVTDataProviderShape,
+} from "./MVTDataProvider";
+
+// Unused prop check. First type argument is the *augmented* MVTDataProviderShape
+// (declared in MVTDataProvider.ts) — Cesium's raw `MVTDataProvider` d.ts only
+// exposes a static `fromUrl` with no instance members, so the augmentation is
+// what the wrapper actually instantiates and exposes.
+type UnusedProps = UnusedCesiumProps<
+  MVTDataProviderShape,
+  Omit<
+    MVTDataProviderProps,
+    keyof MVTDataProviderOtherProps | keyof MVTDataProviderCesiumReadonlyProps
+  >,
+  {},
+  IgnoredProps
+>;
+// `tileset` is a read-only getter consumers reach via ref / `getTileset(provider)`,
+// not via a wrapper prop. The other augmented members (`update`, `isDestroyed`,
+// `destroy`) are functions and are filtered automatically by UnusedCesiumProps.
+type IgnoredProps = "tileset";
+
+expectType<TypeEqual<never, UnusedProps>>(true);
+
+it("should be compiled", () => {});

--- a/src/MVTDataProvider/MVTDataProvider.ts
+++ b/src/MVTDataProvider/MVTDataProvider.ts
@@ -1,0 +1,128 @@
+import type { Rectangle, Resource, Cesium3DTileset } from "cesium";
+import { MVTDataProvider as CesiumMVTDataProvider } from "cesium";
+
+import type { PickCesiumProps } from "../core";
+import { createCesiumComponent } from "../core";
+
+// Cesium 1.142 ships `MVTDataProvider` as @experimental and its .d.ts exposes
+// only the static `fromUrl` (whose return type is incorrectly typed as `void`).
+// At runtime the class has `show`, `tileset`, `update(frameState)`, `isDestroyed`,
+// and `destroy` — see node_modules/@cesium/engine/Source/Scene/MVTDataProvider.js
+// and its parent UrlTemplate3DTilesDataProvider.js. Augment locally so the
+// wrapper can attach the provider to the primitive collection, react to `show`
+// changes, and clean up on unmount.
+export type MVTDataProviderShape = CesiumMVTDataProvider & {
+  show: boolean;
+  readonly tileset: Cesium3DTileset | undefined;
+  update: (frameState: unknown) => void;
+  isDestroyed: () => boolean;
+  destroy: () => void;
+};
+
+/*
+@summary
+`MVTDataProvider` loads Mapbox Vector Tiles (MVT) as runtime-generated 3D Tiles.
+
+Despite the "DataProvider" name, this class is **not** an `ImageryProvider` or
+`TerrainProvider`. It implements its own `update(frameState)` and attaches
+directly to `Scene#primitives`, like a `Cesium3DTileset`. Use it as a
+top-level child of `<Viewer>`/`<CesiumWidget>`, **not** as a prop on an
+`<ImageryLayer>`.
+
+This API is experimental and subject to change without standard deprecation.
+*/
+
+/*
+@scope
+Inside [Viewer](/components/Viewer) or [CesiumWidget](/components/CesiumWidget) component.
+An MVTDataProvider object will be attached to the PrimitiveCollection of the Viewer or CesiumWidget.
+*/
+
+export type MVTDataProviderCesiumProps = PickCesiumProps<
+  MVTDataProviderShape,
+  typeof cesiumProps
+>;
+
+export type MVTDataProviderCesiumReadonlyProps = {
+  /** Minimum zoom level represented in the generated tileset. Fixed at creation time. */
+  minZoom?: number;
+  /** Maximum zoom level represented in the generated tileset. Fixed at creation time. */
+  maxZoom?: number;
+  /** Optional geographic extent (radians) constraining the generated tile tree. Fixed at creation time. */
+  extent?: Rectangle;
+  /** MVT property name to use as feature ID. Fixed at creation time. */
+  featureIdProperty?: string;
+};
+
+export type MVTDataProviderOtherProps = {
+  /** Required URL template containing `{z}`/`{x}`/`{y}` placeholders. */
+  url: string | Resource;
+  /** Fires once `fromUrl` resolves. Reach `provider.tileset` (or call `getTileset(provider)`) here to apply clipping/styling. */
+  onReady?: (provider: MVTDataProviderShape) => void;
+  /** Fires if `fromUrl` rejects. */
+  onError?: (err: unknown) => void;
+};
+
+export type MVTDataProviderProps = MVTDataProviderCesiumProps &
+  MVTDataProviderCesiumReadonlyProps &
+  MVTDataProviderOtherProps;
+
+const cesiumProps = ["show"] as const;
+
+const cesiumReadonlyProps = ["minZoom", "maxZoom", "extent", "featureIdProperty"] as const;
+
+// `url` is a user-supplied prop (not a real Cesium property), but treated as
+// read-only so changing it at runtime triggers a destroy+recreate.
+const cesiumReadonlyPropsWithUrl = [...cesiumReadonlyProps, "url"] as const;
+
+export const otherProps = ["url", "onReady", "onError"] as const;
+
+const MVTDataProvider = createCesiumComponent<MVTDataProviderShape, MVTDataProviderProps>({
+  name: "MVTDataProvider",
+  async create(context, props) {
+    if (!context.primitiveCollection) return;
+
+    const { url, minZoom, maxZoom, extent, featureIdProperty, onReady, onError } = props;
+    let element: MVTDataProviderShape;
+    try {
+      // Cesium 1.142's MVTDataProvider.fromUrl is typed `void` in the d.ts.
+      // At runtime it returns Promise<MVTDataProvider>. Cast to the augmented shape.
+      element = (await (CesiumMVTDataProvider.fromUrl(url, {
+        minZoom,
+        maxZoom,
+        extent,
+        featureIdProperty,
+      }) as unknown as Promise<MVTDataProviderShape>));
+      onReady?.(element);
+    } catch (e) {
+      onError?.(e);
+      return;
+    }
+
+    // MVTDataProvider isn't a Cesium `Primitive` in the type hierarchy, but the
+    // primitive collection accepts any object with an `update(frameState)` method.
+    context.primitiveCollection.add(element as unknown as object);
+    return element;
+  },
+  destroy(element, context) {
+    if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
+      context.primitiveCollection.remove(element as unknown as object);
+    }
+    if (!element.isDestroyed()) {
+      element.destroy();
+    }
+  },
+  cesiumProps,
+  cesiumReadonlyProps: cesiumReadonlyPropsWithUrl,
+  otherProps,
+});
+
+export default MVTDataProvider;
+
+/**
+ * Typed accessor for the internal `Cesium3DTileset` that an `MVTDataProvider`
+ * generates. Use inside `onReady` (or via a ref after mount) to apply clipping,
+ * styling, or to call `zoomTo` on the tileset.
+ */
+export const getTileset = (provider: MVTDataProviderShape): Cesium3DTileset | undefined =>
+  provider.tileset;

--- a/src/MVTDataProvider/MVTDataProvider.ts
+++ b/src/MVTDataProvider/MVTDataProvider.ts
@@ -104,10 +104,14 @@ const MVTDataProvider = createCesiumComponent<MVTDataProviderShape, MVTDataProvi
   },
   destroy(element, context) {
     if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      // PrimitiveCollection.remove() calls destroy() on removed primitives when
-      // destroyPrimitives is true (the default on Viewer/CesiumWidget). No need
-      // to call element.destroy() ourselves.
       context.primitiveCollection.remove(element);
+    }
+    // Explicit destroy guards the edge case where the provider is mounted into
+    // a PrimitiveCollection with destroyPrimitives=false (in which case
+    // remove() does not call destroy()). isDestroyed/destroy are part of the
+    // augmented shape and present at runtime via UrlTemplate3DTilesDataProvider.
+    if (!element.isDestroyed()) {
+      element.destroy();
     }
   },
   cesiumProps,

--- a/src/MVTDataProvider/MVTDataProvider.ts
+++ b/src/MVTDataProvider/MVTDataProvider.ts
@@ -87,29 +87,27 @@ const MVTDataProvider = createCesiumComponent<MVTDataProviderShape, MVTDataProvi
     try {
       // Cesium 1.142's MVTDataProvider.fromUrl is typed `void` in the d.ts.
       // At runtime it returns Promise<MVTDataProvider>. Cast to the augmented shape.
-      element = (await (CesiumMVTDataProvider.fromUrl(url, {
+      element = await (CesiumMVTDataProvider.fromUrl(url, {
         minZoom,
         maxZoom,
         extent,
         featureIdProperty,
-      }) as unknown as Promise<MVTDataProviderShape>));
+      }) as unknown as Promise<MVTDataProviderShape>);
       onReady?.(element);
     } catch (e) {
       onError?.(e);
       return;
     }
 
-    // MVTDataProvider isn't a Cesium `Primitive` in the type hierarchy, but the
-    // primitive collection accepts any object with an `update(frameState)` method.
-    context.primitiveCollection.add(element as unknown as object);
+    context.primitiveCollection.add(element);
     return element;
   },
   destroy(element, context) {
     if (context.primitiveCollection && !context.primitiveCollection.isDestroyed()) {
-      context.primitiveCollection.remove(element as unknown as object);
-    }
-    if (!element.isDestroyed()) {
-      element.destroy();
+      // PrimitiveCollection.remove() calls destroy() on removed primitives when
+      // destroyPrimitives is true (the default on Viewer/CesiumWidget). No need
+      // to call element.destroy() ourselves.
+      context.primitiveCollection.remove(element);
     }
   },
   cesiumProps,

--- a/src/MVTDataProvider/index.ts
+++ b/src/MVTDataProvider/index.ts
@@ -1,1 +1,6 @@
-export { default, type MVTDataProviderProps, getTileset } from "./MVTDataProvider";
+export {
+  default,
+  type MVTDataProviderProps,
+  type MVTDataProviderShape,
+  getTileset,
+} from "./MVTDataProvider";

--- a/src/MVTDataProvider/index.ts
+++ b/src/MVTDataProvider/index.ts
@@ -1,0 +1,1 @@
+export { default, type MVTDataProviderProps, getTileset } from "./MVTDataProvider";

--- a/src/Model/Model.stories.tsx
+++ b/src/Model/Model.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react";
-import { Transforms, Cartesian3, Resource } from "cesium";
+import { Transforms, Cartesian3, Resource, EdgeDisplayMode } from "cesium";
 
 import CameraFlyTo from "../CameraFlyTo";
 import { events } from "../core/storybook";
@@ -46,6 +46,31 @@ export const FromPromiseResource: Story = {
         modelMatrix={modelMatrix}
         minimumPixelSize={128}
         maximumScale={20000}
+        onReady={action("onReady")}
+        {...events}
+      />
+    </Viewer>
+  ),
+};
+
+/**
+ * Demonstrates the new `edgeDisplayMode` prop (Cesium 1.142+).
+ * Visible effect requires source assets containing the
+ * `EXT_mesh_primitive_edge_visibility` glTF extension. `Cesium_Air.glb` does
+ * not, so this story documents the prop without producing a visual difference;
+ * point it at an edge-equipped glTF locally to see CAD wireframe rendering.
+ */
+export const EdgeDisplay: Story = {
+  render: args => (
+    <Viewer full>
+      <CameraFlyTo destination={cameraDest} duration={0} />
+      <Model
+        {...args}
+        url="Cesium_Air.glb"
+        modelMatrix={modelMatrix}
+        minimumPixelSize={128}
+        maximumScale={20000}
+        edgeDisplayMode={EdgeDisplayMode.EDGES_ONLY}
         onReady={action("onReady")}
         {...events}
       />

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -35,6 +35,7 @@ const cesiumProps = [
   "debugShowBoundingVolume",
   "debugWireframe",
   "distanceDisplayCondition",
+  "edgeDisplayMode",
   "enableVerticalExaggeration",
   "featureIdLabel",
   "heightReference",

--- a/src/ScreenSpaceEvent/ScreenSpaceEvent.stories.tsx
+++ b/src/ScreenSpaceEvent/ScreenSpaceEvent.stories.tsx
@@ -1,7 +1,17 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { KeyboardEventModifier, ScreenSpaceEventType } from "cesium";
-import { useState } from "react";
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  KeyboardEventModifier,
+  ScreenSpaceEventType,
+  Viewer as CesiumViewer,
+} from "cesium";
+import { useRef, useState } from "react";
 
+import { CesiumComponentRef } from "../core";
+import Entity from "../Entity";
+import PointGraphics from "../PointGraphics";
 import ScreenSpaceEventHandler from "../ScreenSpaceEventHandler";
 import Viewer from "../Viewer";
 
@@ -14,34 +24,79 @@ export default {
   component: ScreenSpaceEvent,
 } as Meta;
 
+type Marker = { id: number; position: Cartesian3; color: Color; label: string };
+
 /**
  * Demonstrates plain, single-modifier, and chord-modifier bindings on the same
- * event type. Click the viewer to see which combination fired in the overlay.
- * Chord modifiers (`[ALT, SHIFT]`) require Cesium 1.142+.
+ * event type. Each binding drops a colored point on the globe at the click
+ * location, so it's obvious which combination fired:
+ *
+ * - **Plain click** → red point
+ * - **ALT + click** → yellow point
+ * - **ALT + SHIFT + click** → cyan point (chord — requires Cesium 1.142+)
+ *
+ * The overlay also logs the last few events for confirmation. Clicks that miss
+ * the globe (e.g. above the horizon) only update the log.
  */
 export const Chord: Story = {
   render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
+    const viewerRef = useRef<CesiumComponentRef<CesiumViewer>>(null);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const counterRef = useRef(0);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [markers, setMarkers] = useState<Marker[]>([]);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [log, setLog] = useState<string[]>([]);
-    const append = (line: string) => setLog(prev => [...prev.slice(-5), line]);
+
+    const pickGlobe = (screen: Cartesian2): Cartesian3 | undefined => {
+      const viewer = viewerRef.current?.cesiumElement;
+      if (!viewer) return undefined;
+      const ray = viewer.camera.getPickRay(screen);
+      if (!ray) return undefined;
+      const hit = viewer.scene.globe.pick(ray, viewer.scene);
+      return hit ?? undefined;
+    };
+
+    const handle =
+      (label: string, color: Color) =>
+      (e: { position: Cartesian2 } | { startPosition: Cartesian2; endPosition: Cartesian2 }) => {
+        if (!("position" in e)) return;
+        setLog(prev => [...prev.slice(-5), label]);
+        const position = pickGlobe(e.position);
+        if (!position) return;
+        const id = counterRef.current++;
+        setMarkers(prev => [...prev.slice(-19), { id, position, color, label }]);
+      };
+
     return (
-      <Viewer full>
+      <Viewer full ref={viewerRef}>
         <ScreenSpaceEventHandler>
           <ScreenSpaceEvent
-            action={() => append("LEFT_CLICK")}
+            action={handle("LEFT_CLICK", Color.RED)}
             type={ScreenSpaceEventType.LEFT_CLICK}
           />
           <ScreenSpaceEvent
-            action={() => append("LEFT_CLICK + ALT")}
+            action={handle("LEFT_CLICK + ALT", Color.YELLOW)}
             modifier={KeyboardEventModifier.ALT}
             type={ScreenSpaceEventType.LEFT_CLICK}
           />
           <ScreenSpaceEvent
-            action={() => append("LEFT_CLICK + ALT + SHIFT")}
+            action={handle("LEFT_CLICK + ALT + SHIFT", Color.CYAN)}
             modifier={[KeyboardEventModifier.ALT, KeyboardEventModifier.SHIFT]}
             type={ScreenSpaceEventType.LEFT_CLICK}
           />
         </ScreenSpaceEventHandler>
+        {markers.map(m => (
+          <Entity key={m.id} position={m.position}>
+            <PointGraphics
+              pixelSize={14}
+              color={m.color}
+              outlineColor={Color.WHITE}
+              outlineWidth={2}
+            />
+          </Entity>
+        ))}
         <div
           style={{
             position: "absolute",
@@ -54,10 +109,28 @@ export const Chord: Story = {
             fontSize: 12,
             borderRadius: 4,
             pointerEvents: "none",
-            minWidth: 240,
+            minWidth: 260,
           }}>
-          <div>Click anywhere on the globe:</div>
-          {log.length === 0 ? <div>· no events yet</div> : log.map((l, i) => <div key={i}>· {l}</div>)}
+          <div style={{ marginBottom: 8, fontWeight: 600 }}>
+            Try clicking the globe:
+          </div>
+          <div style={{ opacity: 0.85, lineHeight: 1.5 }}>
+            <div>
+              <span style={{ color: "#ff6b6b" }}>●</span> plain click
+            </div>
+            <div>
+              <span style={{ color: "#ffe066" }}>●</span> ALT + click
+            </div>
+            <div>
+              <span style={{ color: "#66e0ff" }}>●</span> ALT + SHIFT + click
+              (chord)
+            </div>
+          </div>
+          <div style={{ marginTop: 10, borderTop: "1px solid #444", paddingTop: 8 }}>
+            {log.length === 0
+              ? <div style={{ opacity: 0.6 }}>· no events yet</div>
+              : log.map((l, i) => <div key={i}>· {l}</div>)}
+          </div>
         </div>
       </Viewer>
     );

--- a/src/ScreenSpaceEvent/ScreenSpaceEvent.stories.tsx
+++ b/src/ScreenSpaceEvent/ScreenSpaceEvent.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { KeyboardEventModifier, ScreenSpaceEventType } from "cesium";
+import { useState } from "react";
+
+import ScreenSpaceEventHandler from "../ScreenSpaceEventHandler";
+import Viewer from "../Viewer";
+
+import ScreenSpaceEvent from "./ScreenSpaceEvent";
+
+type Story = StoryObj<typeof ScreenSpaceEvent>;
+
+export default {
+  title: "ScreenSpaceEvent",
+  component: ScreenSpaceEvent,
+} as Meta;
+
+/**
+ * Demonstrates plain, single-modifier, and chord-modifier bindings on the same
+ * event type. Click the viewer to see which combination fired in the overlay.
+ * Chord modifiers (`[ALT, SHIFT]`) require Cesium 1.142+.
+ */
+export const Chord: Story = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [log, setLog] = useState<string[]>([]);
+    const append = (line: string) => setLog(prev => [...prev.slice(-5), line]);
+    return (
+      <Viewer full>
+        <ScreenSpaceEventHandler>
+          <ScreenSpaceEvent
+            action={() => append("LEFT_CLICK")}
+            type={ScreenSpaceEventType.LEFT_CLICK}
+          />
+          <ScreenSpaceEvent
+            action={() => append("LEFT_CLICK + ALT")}
+            modifier={KeyboardEventModifier.ALT}
+            type={ScreenSpaceEventType.LEFT_CLICK}
+          />
+          <ScreenSpaceEvent
+            action={() => append("LEFT_CLICK + ALT + SHIFT")}
+            modifier={[KeyboardEventModifier.ALT, KeyboardEventModifier.SHIFT]}
+            type={ScreenSpaceEventType.LEFT_CLICK}
+          />
+        </ScreenSpaceEventHandler>
+        <div
+          style={{
+            position: "absolute",
+            top: 16,
+            left: 16,
+            padding: 12,
+            background: "rgba(0,0,0,0.75)",
+            color: "white",
+            fontFamily: "monospace",
+            fontSize: 12,
+            borderRadius: 4,
+            pointerEvents: "none",
+            minWidth: 240,
+          }}>
+          <div>Click anywhere on the globe:</div>
+          {log.length === 0 ? <div>· no events yet</div> : log.map((l, i) => <div key={i}>· {l}</div>)}
+        </div>
+      </Viewer>
+    );
+  },
+};

--- a/src/ScreenSpaceEvent/ScreenSpaceEvent.test.tsx
+++ b/src/ScreenSpaceEvent/ScreenSpaceEvent.test.tsx
@@ -1,0 +1,84 @@
+import { render } from "@testing-library/react";
+import { KeyboardEventModifier, ScreenSpaceEventType } from "cesium";
+import { expect, it, vi } from "vitest";
+
+import { CesiumContext } from "../core/context";
+
+import ScreenSpaceEvent from "./ScreenSpaceEvent";
+
+function mountWith({
+  action,
+  modifier,
+}: {
+  action: () => void;
+  modifier?: KeyboardEventModifier | KeyboardEventModifier[];
+}) {
+  const setInputAction = vi.fn();
+  const removeInputAction = vi.fn();
+  const isDestroyed = vi.fn().mockReturnValue(false);
+  const screenSpaceEventHandler = { setInputAction, removeInputAction, isDestroyed } as any;
+  const utils = render(
+    <CesiumContext.Provider value={{ screenSpaceEventHandler } as any}>
+      <ScreenSpaceEvent
+        action={action}
+        modifier={modifier}
+        type={ScreenSpaceEventType.LEFT_CLICK}
+      />
+    </CesiumContext.Provider>,
+  );
+  return { ...utils, setInputAction, removeInputAction, screenSpaceEventHandler };
+}
+
+it("forwards a single KeyboardEventModifier verbatim to setInputAction", () => {
+  const action = vi.fn();
+  const { setInputAction } = mountWith({ action, modifier: KeyboardEventModifier.ALT });
+
+  expect(setInputAction).toHaveBeenCalledTimes(1);
+  expect(setInputAction).toHaveBeenCalledWith(
+    action,
+    ScreenSpaceEventType.LEFT_CLICK,
+    KeyboardEventModifier.ALT,
+  );
+});
+
+it("forwards a KeyboardEventModifier[] verbatim to setInputAction (chord)", () => {
+  const action = vi.fn();
+  const chord = [KeyboardEventModifier.ALT, KeyboardEventModifier.SHIFT];
+  const { setInputAction } = mountWith({ action, modifier: chord });
+
+  expect(setInputAction).toHaveBeenCalledTimes(1);
+  expect(setInputAction).toHaveBeenCalledWith(action, ScreenSpaceEventType.LEFT_CLICK, chord);
+});
+
+it("does not re-call setInputAction when a content-equal array is passed on re-render", () => {
+  const action = vi.fn();
+  const setInputAction = vi.fn();
+  const removeInputAction = vi.fn();
+  const isDestroyed = vi.fn().mockReturnValue(false);
+  const screenSpaceEventHandler = { setInputAction, removeInputAction, isDestroyed } as any;
+  const ctx = { screenSpaceEventHandler } as any;
+
+  const { rerender } = render(
+    <CesiumContext.Provider value={ctx}>
+      <ScreenSpaceEvent
+        action={action}
+        modifier={[KeyboardEventModifier.ALT, KeyboardEventModifier.SHIFT]}
+        type={ScreenSpaceEventType.LEFT_CLICK}
+      />
+    </CesiumContext.Provider>,
+  );
+
+  // Same content, different reference.
+  rerender(
+    <CesiumContext.Provider value={ctx}>
+      <ScreenSpaceEvent
+        action={action}
+        modifier={[KeyboardEventModifier.ALT, KeyboardEventModifier.SHIFT]}
+        type={ScreenSpaceEventType.LEFT_CLICK}
+      />
+    </CesiumContext.Provider>,
+  );
+
+  expect(setInputAction).toHaveBeenCalledTimes(1);
+  expect(removeInputAction).not.toHaveBeenCalled();
+});

--- a/src/ScreenSpaceEvent/ScreenSpaceEvent.ts
+++ b/src/ScreenSpaceEvent/ScreenSpaceEvent.ts
@@ -1,6 +1,6 @@
 import type { ScreenSpaceEventType, KeyboardEventModifier, Cartesian2 } from "cesium";
 import type { FC } from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useCesium } from "../core";
 
@@ -23,12 +23,31 @@ export type ScreenSpaceEventProps = {
   action?: (
     e: { position: Cartesian2 } | { startPosition: Cartesian2; endPosition: Cartesian2 },
   ) => void;
-  modifier?: KeyboardEventModifier;
+  /**
+   * Keyboard modifier(s) that must be held for the action to fire.
+   *
+   * - Single value (`KeyboardEventModifier.ALT`): action fires when only that modifier is held.
+   * - Array (`[ALT, SHIFT]`): chord — action fires only when all listed modifiers are held simultaneously.
+   *
+   * Multi-key chords require Cesium 1.142+. Content-equal but reference-fresh arrays do not retrigger the underlying `setInputAction` call.
+   */
+  modifier?: KeyboardEventModifier | KeyboardEventModifier[];
   type: ScreenSpaceEventType;
 };
 
 const ScreenSpaceEvent: FC<ScreenSpaceEventProps> = ({ action, modifier, type }) => {
   const ctx = useCesium();
+
+  // Stable identity for the modifier dep: numeric-sort + comma-join. Without
+  // this, `modifier={[ALT, SHIFT]}` thrashes setInputAction on every render
+  // because the array reference is fresh each time.
+  const modifierKey = useMemo(
+    () =>
+      Array.isArray(modifier)
+        ? [...modifier].sort((a, b) => a - b).join(",")
+        : modifier ?? "",
+    [modifier],
+  );
 
   useEffect(() => {
     if (!ctx.screenSpaceEventHandler || ctx.screenSpaceEventHandler.isDestroyed()) return;
@@ -42,7 +61,8 @@ const ScreenSpaceEvent: FC<ScreenSpaceEventProps> = ({ action, modifier, type })
       ctx.screenSpaceEventHandler.removeInputAction(type, modifier);
     }
     return undefined;
-  }, [action, ctx.screenSpaceEventHandler, modifier, type]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [action, ctx.screenSpaceEventHandler, modifierKey, type]);
 
   return null;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,10 @@ export { default as LabelGraphics, type LabelGraphicsProps } from "./LabelGraphi
 export { default as Model, type ModelProps } from "./Model";
 export { default as ModelGraphics, type ModelGraphicsProps } from "./ModelGraphics";
 export { default as Moon, type MoonProps } from "./Moon";
+export {
+  default as MVTDataProvider,
+  type MVTDataProviderProps,
+} from "./MVTDataProvider";
 export { default as ParticleSystem, type ParticleSystemProps } from "./ParticleSystem";
 export { default as PathGraphics, type PathGraphicsProps } from "./PathGraphics";
 export { default as PlaneGraphics, type PlaneGraphicsProps } from "./PlaneGraphics";

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export { default as GeoJsonDataSource, type GeoJsonDataSourceProps } from "./Geo
 export {
   default as GeoJsonPrimitive,
   type GeoJsonPrimitiveProps,
+  type GeoJsonPrimitiveShape,
 } from "./GeoJsonPrimitive";
 export { default as Globe, type GlobeProps } from "./Globe";
 export {
@@ -99,6 +100,7 @@ export { default as Moon, type MoonProps } from "./Moon";
 export {
   default as MVTDataProvider,
   type MVTDataProviderProps,
+  type MVTDataProviderShape,
   getTileset,
 } from "./MVTDataProvider";
 export { default as ParticleSystem, type ParticleSystemProps } from "./ParticleSystem";

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ export { default as Moon, type MoonProps } from "./Moon";
 export {
   default as MVTDataProvider,
   type MVTDataProviderProps,
+  getTileset,
 } from "./MVTDataProvider";
 export { default as ParticleSystem, type ParticleSystemProps } from "./ParticleSystem";
 export { default as PathGraphics, type PathGraphicsProps } from "./PathGraphics";

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,10 @@ export {
 export { default as EntityDescription, type EntityDescriptionProps } from "./EntityDescription";
 export { default as Fog, type FogProps } from "./Fog";
 export { default as GeoJsonDataSource, type GeoJsonDataSourceProps } from "./GeoJsonDataSource";
+export {
+  default as GeoJsonPrimitive,
+  type GeoJsonPrimitiveProps,
+} from "./GeoJsonPrimitive";
 export { default as Globe, type GlobeProps } from "./Globe";
 export {
   default as Google2DImageryProvider,

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,10 +527,10 @@
   dependencies:
     css-tree "^3.0.0"
 
-"@cesium/engine@^25.0.0":
-  version "25.0.0"
-  resolved "https://registry.yarnpkg.com/@cesium/engine/-/engine-25.0.0.tgz#97c15f0ed73701159e6f60b2ec4df4dc861ef43a"
-  integrity sha512-vJZfgAAB7WTvUPsI8dFV+wKleweCZgpJj1ckcTIERnC+NWvJ9bjlAx0xPl0We57NoQKcdMDy+6UiFjOvPB/yGg==
+"@cesium/engine@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@cesium/engine/-/engine-26.0.0.tgz#05bc6612815cbe345e8e3f7444a2a8d212583f19"
+  integrity sha512-iV2mUQHUffYBEQii7n8CQ0XA1eSmcetOedsLoZvDJG6LW9aRHxL008rVvGnnZelQVRUQWNFFX5/+Tos3TBIIcw==
   dependencies:
     "@cesium/wasm-splats" "^0.1.0-alpha.2"
     "@spz-loader/core" "0.3.1"
@@ -549,7 +549,7 @@
     mersenne-twister "^1.1.0"
     meshoptimizer "^1.0.1"
     pako "^2.0.4"
-    protobufjs "^8.0.0"
+    protobufjs "^8.5.0"
     rbush "^4.0.1"
     topojson-client "^3.1.0"
     urijs "^1.19.7"
@@ -559,12 +559,12 @@
   resolved "https://registry.npmjs.org/@cesium/wasm-splats/-/wasm-splats-0.1.0-alpha.2.tgz"
   integrity sha512-t9pMkknv31hhIbLpMa8yPvmqfpvs5UkUjgqlQv9SeO8VerCXOYnyP8/486BDaFrztM0A7FMbRjsXtNeKvqQghA==
 
-"@cesium/widgets@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@cesium/widgets/-/widgets-15.0.0.tgz#4993d11940bbcb508efa8b21cad10c4bcfe31b16"
-  integrity sha512-a0udi+EKEeCyM4F+pxp9Qx8HXgh2eWVQrksxGO4lSu3f35XWc+eKdYiJBEP2t1d4tjw2MxOsjbVyMj7VQZ4JDw==
+"@cesium/widgets@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@cesium/widgets/-/widgets-16.0.0.tgz#a8aafe34d120ee606cb233a9bd2503f20e74962e"
+  integrity sha512-52PO61PKm6Cut1BR/OqrPLmDXL9lk7iwGHXWbWQpg1pJT8SaJ7PXyLqcAPz+6VTYXspmE4D6Xo0PgIav33dEEQ==
   dependencies:
-    "@cesium/engine" "^25.0.0"
+    "@cesium/engine" "^26.0.0"
     nosleep.js "^0.12.0"
 
 "@cspotcode/source-map-support@^0.8.0":
@@ -848,10 +848,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-3.0.5.tgz#88e9bf4d11d2b19c082e78ebe7ce88724a5eb091"
   integrity sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==
 
-"@eslint/plugin-kit@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz#c4125fd015eceeb09b793109fdbcd4dd0a02d346"
-  integrity sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==
+"@eslint/plugin-kit@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz#4b0962f3f2c7ce8bc98b3ecfe34525c09d2cb729"
+  integrity sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==
   dependencies:
     "@eslint/core" "^1.2.1"
     levn "^0.4.1"
@@ -1692,59 +1692,6 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.3.6.tgz#3569708bd4be4d8870ba32bf1c456dac81600d97"
   integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
 
-"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz"
-  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
-
-"@protobufjs/base64@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz"
-  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
-
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
-
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz"
-  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
-
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz"
-  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
-
-"@protobufjs/float@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz"
-  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
-
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz"
-  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
-
-"@protobufjs/path@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz"
-  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
-
-"@protobufjs/pool@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz"
-  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
-
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
-  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
-
 "@rolldown/binding-android-arm64@1.0.0-rc.13":
   version "1.0.0-rc.13"
   resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz#0862753ca7cad78350240cd68fc79150606b42c4"
@@ -2419,13 +2366,6 @@
   integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
-
-"@types/node@>=13.7.0":
-  version "20.12.2"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz"
-  integrity sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==
-  dependencies:
-    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -3409,13 +3349,13 @@ caniuse-lite@^1.0.30001759:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz#4a78d8a797fd4124ebaab2043df942eb091648ee"
   integrity sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==
 
-cesium@1.141.0:
-  version "1.141.0"
-  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.141.0.tgz#02f84b19f4b7e83a78679382431c81ca7d935237"
-  integrity sha512-bRwgABDjsXRqNLjeJAxSlCrWCTvAt/yWJD30fY5CbqtoEKR6g/YCOcJW37vk4w/Gq3uMW7sF1uP74ajRrktjEw==
+cesium@1.142.0:
+  version "1.142.0"
+  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.142.0.tgz#c47ac4760635f19734e45a2b8ee8f790bd541f23"
+  integrity sha512-Z6mBxdeBS0lEXM7WAQgG8Q0FovXYAJpZsMOSWgd7dH28Ov+djJxWOlUMiG8jOai0TzeOYdYsMLgnYb2uB/aI/A==
   dependencies:
-    "@cesium/engine" "^25.0.0"
-    "@cesium/widgets" "^15.0.0"
+    "@cesium/engine" "^26.0.0"
+    "@cesium/widgets" "^16.0.0"
 
 chai@^5.2.0:
   version "5.3.3"
@@ -3631,10 +3571,10 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-concurrently@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-10.0.0.tgz#ceb3782d36a620ae7c05ff8085076c0d96323479"
-  integrity sha512-DRrk10z3sVPpguNe8od2cGNqZGqbT15rwAnxD4dG3b78mdNNb/gJyr8T834Oj518WcBmTktrt4FhdwZn09ZWSg==
+concurrently@^10.0.1:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-10.0.3.tgz#0ae4bf732e958b1a607b47896dcaa836b72514e8"
+  integrity sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==
   dependencies:
     chalk "5.6.2"
     rxjs "7.8.2"
@@ -4399,17 +4339,17 @@ eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-eslint@10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.4.0.tgz#d86b6c405de0f19f3318c47139b8cb6771b3f592"
-  integrity sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==
+eslint@10.4.1:
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.4.1.tgz#f6640b176e0912246d9ddbf8fcfa5e8b7f02445a"
+  integrity sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==
   dependencies:
     "@eslint-community/eslint-utils" "^4.8.0"
     "@eslint-community/regexpp" "^4.12.2"
     "@eslint/config-array" "^0.23.5"
     "@eslint/config-helpers" "^0.6.0"
     "@eslint/core" "^1.2.1"
-    "@eslint/plugin-kit" "^0.7.1"
+    "@eslint/plugin-kit" "^0.7.2"
     "@humanfs/node" "^0.16.6"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@humanwhocodes/retry" "^0.4.2"
@@ -6431,9 +6371,9 @@ loglevel@^1.9.2:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
   integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
-long@^5.0.0:
+long@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.npmjs.org/long/-/long-5.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 loose-envify@^1.4.0:
@@ -6821,10 +6761,10 @@ npm-normalize-package-bin@^6.0.0:
   resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-6.0.0.tgz#d8cc44d7a9eff2a2a210e9b2442edf3824f2d227"
   integrity sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==
 
-npm-run-all2@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/npm-run-all2/-/npm-run-all2-9.0.0.tgz#5a20924d92ef02b4bf24d04222bb6bee5b94d28d"
-  integrity sha512-NMHaiMWl+kotdoAzVtwElvEh4PLdjAGsdmCJXOGv0rdM4d19FGIa0z0ISFuMklmYgVgQzS4h+jNlowz+q1aojw==
+npm-run-all2@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-all2/-/npm-run-all2-9.0.1.tgz#1bd4ee405ab12527643e3d36cd236f7e9f50a25c"
+  integrity sha512-ZtK8WXZBUA9x0XD6nxYdFLe86FxpkCTq2LiQxzX0LeXQY/vyAigQZXjjj/xfTwgV4Yqe/vYNIq2W09lrHKTcuQ==
   dependencies:
     ansi-styles "^6.2.1"
     cross-spawn "^7.0.6"
@@ -7441,23 +7381,12 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-protobufjs@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-8.0.0.tgz#d884102c1fe8d0b1e2493789ad37bc7ea47c0893"
-  integrity sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==
+protobufjs@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-8.5.0.tgz#6b8640cc334e06fc2548524bdac21ad970092dfe"
+  integrity sha512-df1jWDPA5VIBNRtuAHjqr09f2qN5D4Vke1wYqOQg1XJ7ZDpA7BD6L7E4tyChgGRLB5hqk2m79Zsy0WHwV9a84A==
   dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
+    long "^5.3.2"
 
 proxy-from-env@^2.1.0:
   version "2.1.0"
@@ -8883,11 +8812,6 @@ unbox-primitive@^1.1.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
 undici@^7.25.0:
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
@@ -9188,10 +9112,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-polyfill@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz"
-  integrity sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==
+web-streams-polyfill@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.3.0.tgz#2f5fe004e2c53f09f7e03aef25b892953cab99a6"
+  integrity sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw==
 
 webidl-conversions@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
## Summary

Brings every new Cesium 1.142 public API surface into Resium's component layer, plus the four queued dev-tooling patches. Single-PR scope so consumers can adopt 1.142 with one upgrade.

### Two new components

- **`MVTDataProvider`** — loads Mapbox Vector Tiles (`.mvt`/`.pbf`) from a `{z}/{x}/{y}` URL template and converts them to 3D Tiles at runtime. Internal `Cesium3DTileset` is reachable via the typed `getTileset(provider)` helper so consumers can apply `Cesium3DTileStyle`, clipping, and feature picking (including `EXT_structural_metadata` property access). Marked experimental in JSDoc.
- **`GeoJsonPrimitive`** — high-throughput companion to `GeoJsonDataSource` that loads GeoJSON directly into the three Buffer collections, bypassing the entity/DataSource layer. Async `fromUrl` plus opt-in Suspense for the `url`/`data` prop. Marked experimental.

Both wrappers ship with an exported `*Shape` type augmentation that compensates for incomplete `.d.ts` declarations Cesium emits for these experimental classes (notably `show`, and for MVT also `tileset`/`update`/`isDestroyed`/`destroy`).

### New props on existing components

- `edgeDisplayMode` on `Model`, `Cesium3DTileset`, `GooglePhotorealistic3DTileset` (modes: `SURFACES_ONLY` default, `SURFACES_AND_EDGES`, `EDGES_ONLY` for CAD-style wireframe). Effect requires source assets carrying the `EXT_mesh_primitive_edge_visibility` glTF extension.
- `boundingVolume` and `blendOption` constructor props on `BufferPointCollection`, `BufferPolylineCollection`, `BufferPolygonCollection`. Pair `blendOption` with an alpha-aware `BufferPrimitiveMaterial` (or its `BufferPoint/Polyline/PolygonMaterial` subclass) to render translucency — story variants demonstrate the pairing.
- `boundingVolume` is now interpreted in **world space** (Cesium 1.142+). Documented in `docs/src/content/docs/migration.md` under a new `v1.23` section.

### Widened prop

- `ScreenSpaceEvent.modifier` now accepts `KeyboardEventModifier | KeyboardEventModifier[]` so consumers can register chord shortcuts like `[ALT, SHIFT]+LEFT_CLICK` that don't collide with default camera controls. Backward-compatible — the single-value form still works. Internal `useMemo` stable-keys the array so content-equal-but-reference-fresh re-renders don't thrash `setInputAction`/`removeInputAction`; a dedicated runtime test pins this behavior.

### Dependency bumps

- `cesium` 1.141.0 → 1.142.0
- `concurrently` 10.0.0 → 10.0.1
- `eslint` 10.4.0 → 10.4.1
- `npm-run-all2` 9.0.0 → 9.0.1
- `web-streams-polyfill` 4.2.0 → 4.3.0

## Test plan

- [ ] CI passes `yarn type`, `yarn lint`, `yarn test`, `yarn build` (verified locally: 115 tests across 81 files, all green)
- [ ] CI passes the VRT job (new `GeoJsonPrimitive.vrt.stories.tsx` baseline approved — reg-suit flags it as "1 new item, 0 changed" awaiting human approval, which is standard behavior for new VRT stories)
- [ ] Storybook smoke check — these new/extended stories all render:
  - `GeoJsonPrimitive` (`Inline`, `FromUrl`)
  - `MVTDataProvider` (`Basic`) — renders OpenFreeMap's OpenMapTiles dataset constrained to Manhattan, with a translucent blue `Cesium3DTileStyle`. Paste your own MVT URL (`MapTiler`/`Mapbox`/etc.) into the `url` control to swap data sources.
  - `Model` (`EdgeDisplay` variant)
  - `Cesium3DTileset` (`EdgeDisplay` variant)
  - `BufferPointCollection` / `BufferPolylineCollection` / `BufferPolygonCollection` (`Opaque` + `Translucent` variants)
  - `ScreenSpaceEvent` (`Chord` — interactive overlay logs which combination fired)
- [ ] Migration doc renders correctly under Astro Starlight (verified locally)

## Notes for reviewers

- **The MVTDataProvider demo is necessarily constrained.** Cesium 1.142's `MVTDataProvider` is `@experimental` and not yet performance-tuned for planet-scale rendering. The story applies two constraints required for a smooth demo, both documented in the story JSDoc: (1) an `extent` Rectangle confining the runtime tile tree to Manhattan, and (2) a `Cesium3DTileStyle` applied via `getTileset(provider)` in `onReady` so decoded MVT features are visibly colored. Removing either constraint causes the iframe to become unresponsive — this is upstream Cesium behavior, not a wrapper issue. OpenFreeMap was chosen as the default URL because it ships a stable `/planet/latest/` alias, full z0–z14 coverage, proper MVT content-type, and CORS `*`; it's a funded non-profit, not a hobby endpoint.
- **Debugger pause on "Pause on caught exceptions".** Cesium's `Cesium3DTileset.fromUrl` (which `MVTDataProvider.fromUrl` calls internally) throws `RuntimeError` on failed tile fetches. The wrapper catches this via `try`/`catch` and routes through `onError`, but DevTools with "Pause on caught exceptions" enabled will surface the error before the catch runs. Disable that setting or expect the pause; not a wrapper bug.
- **Experimental-class augmentation churn risk.** Both `GeoJsonPrimitiveShape` and `MVTDataProviderShape` patch around Cesium's incomplete `.d.ts` for these classes. When Cesium fixes the d.ts gaps upstream (1.143+), the intersection types become harmless; if Cesium changes the runtime shape, the augmentation could mask the regression at compile time. Worth tracking as a follow-up.

## Out of scope

- `EXT_mesh_polygon` and `3DTILES_content_gltf_vector` — draft glTF/3D Tiles extensions Cesium loads transparently from extension-bearing assets; no JS class surface to wrap from Resium's side.
- Node engines floor bump — Resium's tests already pass on the current `>=20.19.0` pin against 1.142; no need to tighten now.

## Screenshots

### GooglePhotorealistic3DTileset
- #### Basic
<img width="632" height="403" alt="Screenshot 2026-06-05 at 10 13 54 AM" src="https://github.com/user-attachments/assets/67b92ba1-724a-4c72-9abb-d8f3af68204e" />


### GeoJsonPrimitive

- #### Inline
<img width="868" height="968" alt="Screenshot 2026-06-04 at 4 48 55 PM" src="https://github.com/user-attachments/assets/8114cbcd-b6bb-481d-b71a-f23c4c491964" />

- #### from URL
<img width="870" height="784" alt="Screenshot 2026-06-04 at 4 58 42 PM" src="https://github.com/user-attachments/assets/7000eab7-8e35-4a81-a032-86ed24cb2f26" />

### MVTDataProvider
- #### Basic
<img width="1363" height="944" alt="Screenshot 2026-06-04 at 5 09 39 PM" src="https://github.com/user-attachments/assets/c10489b0-9718-4d26-af77-53b550b2b283" />

### BufferPointCollection
- #### Opaque
<img width="756" height="709" alt="Screenshot 2026-06-04 at 5 13 25 PM" src="https://github.com/user-attachments/assets/e2cd5555-881c-435f-b43b-1e63c1ff9402" />

- #### Translucent
<img width="739" height="768" alt="Screenshot 2026-06-04 at 5 13 32 PM" src="https://github.com/user-attachments/assets/c2b8e669-2057-4e82-a5de-6f5f79616284" />

### BufferPolyLineCollection
- #### Opaque
<img width="825" height="704" alt="Screenshot 2026-06-04 at 5 15 55 PM" src="https://github.com/user-attachments/assets/ad909476-a2e7-4d15-b3d3-e72f9b52957c" />

- #### Translucent
<img width="758" height="621" alt="Screenshot 2026-06-04 at 5 16 01 PM" src="https://github.com/user-attachments/assets/8607f4fd-bf5d-4063-b5a6-91e2c2a97c14" />

### BufferPolygonCollection
- #### Opaque
<img width="799" height="675" alt="Screenshot 2026-06-04 at 5 17 24 PM" src="https://github.com/user-attachments/assets/a519a573-9a2f-4609-ab84-5031680c58d3" />

- #### Translucent
<img width="766" height="648" alt="Screenshot 2026-06-04 at 5 17 30 PM" src="https://github.com/user-attachments/assets/69955e71-a5ed-41fb-a005-a6d78b52a0ac" />

### ScreenSpaceEvent
- #### Chord
<img width="1510" height="838" alt="Screenshot 2026-06-05 at 9 39 38 AM" src="https://github.com/user-attachments/assets/8e33b75f-dba2-4d50-b864-238c783d22a2" />
