### PR TITLE
Fix:  readOnly prop updates in Component not properly propagating

### DIFF
--- a/src/core/component.test.tsx
+++ b/src/core/component.test.tsx
@@ -215,7 +215,7 @@ describe("core/component", () => {
     });
   });
 
-  it("should remount when cesium read only props are updated", async () => {
+  it("should remount when cesium read only props are updated on subsequent rerenders", async () => {
     const cesiumElement = {
       foo: 0,
     };
@@ -257,7 +257,7 @@ describe("core/component", () => {
       expect(createFn).toBeCalledTimes(3);
       expect(destroyFn).toBeCalledTimes(2);
       expect(cesiumElement.foo).toBe(3);
-    })
+    });
   });
 
   it("should call update", async () => {

--- a/src/core/component.test.tsx
+++ b/src/core/component.test.tsx
@@ -215,7 +215,7 @@ describe("core/component", () => {
     });
   });
 
-  it("should remount when cesium read only props are updated on subsequent rerenders", async () => {
+  it("should remount on every cesium read only prop update", async () => {
     const cesiumElement = {
       foo: 0,
     };

--- a/src/core/component.test.tsx
+++ b/src/core/component.test.tsx
@@ -245,11 +245,19 @@ describe("core/component", () => {
 
     rerender(<Component foo={2} />);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(createFn).toBeCalledTimes(2);
       expect(destroyFn).toBeCalledTimes(1);
       expect(cesiumElement.foo).toBe(2);
     });
+
+    rerender(<Component foo={3} />);
+
+    await waitFor(() => {
+      expect(createFn).toBeCalledTimes(3);
+      expect(destroyFn).toBeCalledTimes(2);
+      expect(cesiumElement.foo).toBe(3);
+    })
   });
 
   it("should call update", async () => {

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -234,6 +234,7 @@ export const useCesiumComponent = <Element, Props extends RootComponentInternalP
     }
 
     if (!unmountReadyRef.current) {
+      mountedRef.current = true;
       setMounted(true);
     }
   }, [ctx]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
AI disclosure: I used Claude's Opus 4.8 model to help identify the bug and propose a fix. I wrote the test case myself.

This fixes a problem I was experiencing: Updating a readOnly prop in a primitive component would rerender correctly on the first rerender but would fail to update every rerender thereafter. I also fixed a missing await tag in the test case. 

All tests passed with this change.