### PR TITLE
fix(ci): correct VRT checkout for fork PRs

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -20,11 +20,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # On pull_request, checkout defaults to a detached merge ref, which
-          # breaks reg-keygen-git-hash-plugin ("can't detect branch name").
-          # Check out the PR head branch instead; empty on push, which falls
-          # back to the default ref.
-          ref: ${{ github.head_ref }}
+          # Check out the PR head commit directly from its head repo. This works
+          # for same-repo AND fork PRs — the previous `ref: ${{ github.head_ref }}`
+          # broke on fork PRs whose branch happened to be named `main`, because
+          # actions/checkout resolved the ref against the base repo, checking out
+          # base main instead of the fork's PR branch. It also avoids the
+          # auto-generated merge ref, which reg-keygen-git-hash-plugin can't
+          # reason about ("can't detect branch name").
+          # On push events, both pull_request expressions are null so we fall
+          # back to the workflow's default ref + base repo.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           # reg-keygen-git-hash-plugin walks the git history to find the base
           # commit, so it needs the full history rather than a shallow clone.
           fetch-depth: 0

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Check out the PR head SHA from its head repo so fork PRs whose branch
-          # is named `main` don't accidentally resolve to the base repo's main.
-          # Also avoids the auto-generated merge ref, which reg-keygen can't parse.
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Check out the PR head branch from its head repo so fork PRs whose
+          # branch is named `main` don't resolve against the base repo. Use the
+          # branch name (not SHA) so reg-keygen sees HEAD attached to a branch
+          # rather than detached — it errors otherwise.
+          ref: ${{ github.head_ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           # reg-keygen walks git history to find the base commit — needs full history.
           fetch-depth: 0

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -20,19 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Check out the PR head commit directly from its head repo. This works
-          # for same-repo AND fork PRs — the previous `ref: ${{ github.head_ref }}`
-          # broke on fork PRs whose branch happened to be named `main`, because
-          # actions/checkout resolved the ref against the base repo, checking out
-          # base main instead of the fork's PR branch. It also avoids the
-          # auto-generated merge ref, which reg-keygen-git-hash-plugin can't
-          # reason about ("can't detect branch name").
-          # On push events, both pull_request expressions are null so we fall
-          # back to the workflow's default ref + base repo.
+          # Check out the PR head SHA from its head repo so fork PRs whose branch
+          # is named `main` don't accidentally resolve to the base repo's main.
+          # Also avoids the auto-generated merge ref, which reg-keygen can't parse.
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          # reg-keygen-git-hash-plugin walks the git history to find the base
-          # commit, so it needs the full history rather than a shallow clone.
+          # reg-keygen walks git history to find the base commit — needs full history.
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -20,14 +20,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Check out the PR head branch from its head repo so fork PRs whose
-          # branch is named `main` don't resolve against the base repo. Use the
-          # branch name (not SHA) so reg-keygen sees HEAD attached to a branch
-          # rather than detached — it errors otherwise.
-          ref: ${{ github.head_ref || github.ref }}
+          # Pin to the PR head SHA (immutable — won't drift on a mid-run force-push)
+          # from its head repo, so fork PRs whose branch is named `main` don't
+          # resolve against the base repo. reg-keygen needs HEAD attached to a
+          # branch, so we re-attach in the next step.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           # reg-keygen walks git history to find the base commit — needs full history.
           fetch-depth: 0
+      - name: Attach HEAD to a local branch
+        # `ref: <SHA>` above leaves HEAD detached; reg-keygen-git-hash-plugin errors
+        # with "Can't detect branch name" when HEAD isn't on a named branch.
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git checkout -B "$BRANCH"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".node-version"


### PR DESCRIPTION
Fork PRs whose branch is named `main` (the default for most forks) were being checked out from **our** `main` instead of the fork's PR head, because `ref: ${{ github.head_ref }}` resolved against the base repo. Fixes VRT on #796 and any future external PR — using `pull_request.head.sha` + `pull_request.head.repo.full_name` targets the actual PR head regardless of branch name.

## Test plan
- [ ] CI green
- [ ] After merge, re-run VRT on #796 and confirm it passes